### PR TITLE
feat(web_cmd_search): initial implementation

### DIFF
--- a/web_cmd_search/README.rst
+++ b/web_cmd_search/README.rst
@@ -1,0 +1,14 @@
+==============
+web_cmd_search
+==============
+
+Configurable global record search from the command palette.
+
+Usage
+-----
+
+After installation goto the settings technical menu, find Command Palette Global Search Providers.
+Add records you wish to search for.
+Set any limit (read: max number of results)
+Trigger the command palette and type `!` followed by the search criteria
+

--- a/web_cmd_search/__init__.py
+++ b/web_cmd_search/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/web_cmd_search/__manifest__.py
+++ b/web_cmd_search/__manifest__.py
@@ -1,0 +1,17 @@
+{
+    "name": "web_cmd_palette_search",
+    "summary": "Adds a global command search to quick access records",
+    "author": "Glo Networks",
+    "website": "https://github.com/GlodoUK/odoo-addons",
+    "category": "Uncategorized",
+    "version": "16.0.1.0.0",
+    "depends": ["base", "web"],
+    "data": [
+        "security/ir.model.access.csv",
+        "views/provider.xml",
+    ],
+    "assets": {
+        "web.assets_backend": ["web_cmd_search/static/src/**/*"],
+    },
+    "license": "LGPL-3",
+}

--- a/web_cmd_search/models/__init__.py
+++ b/web_cmd_search/models/__init__.py
@@ -1,0 +1,1 @@
+from . import provider

--- a/web_cmd_search/models/provider.py
+++ b/web_cmd_search/models/provider.py
@@ -1,0 +1,32 @@
+from odoo import api, fields, models
+
+
+class WebCmdSearchProvider(models.Model):
+    _name = "web.cmd.search.provider"
+    _description = "Command Palette Global Search Provider"
+    _order = "sequence asc"
+
+    sequence = fields.Integer(default=10)
+    model_id = fields.Many2one("ir.model", required=True, ondelete="cascade")
+    model_name = fields.Char(related="model_id.model")
+    limit = fields.Integer(default=5)
+
+    @api.model
+    def cmd_search(self, value):
+        results = []
+
+        for provider in self.search([]):
+            results.extend(
+                [
+                    {
+                        "model": provider.model_id.model,
+                        "name": f"{result[1]} - {provider.model_id.name}",
+                        "id": result[0],
+                    }
+                    for result in self.env[provider.model_name].name_search(
+                        value, limit=provider.limit
+                    )
+                ]
+            )
+
+        return results

--- a/web_cmd_search/pyproject.toml
+++ b/web_cmd_search/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["whool"]
+build-backend = "whool.buildapi"

--- a/web_cmd_search/security/ir.model.access.csv
+++ b/web_cmd_search/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_web_cmd_search_provider,access_web_cmd_search_provider,model_web_cmd_search_provider,base.group_user,1,1,1,1

--- a/web_cmd_search/static/src/js/palette.esm.js
+++ b/web_cmd_search/static/src/js/palette.esm.js
@@ -1,0 +1,46 @@
+/** @odoo-module **/
+
+import {_lt} from "@web/core/l10n/translation";
+import {registry} from "@web/core/registry";
+
+registry.category("command_setup").add("!", {
+    debounceDelay: 200,
+    emptyMessage: _lt(
+        "Search for the name of a record.\nIf you cannot find what you're looking for perhaps you need to configure the search providers?"
+    ),
+    name: _lt("Record"),
+    placeholder: _lt("Search for a record..."),
+});
+
+registry.category("command_provider").add("model", {
+    namespace: "!",
+    async provide(env, options) {
+        if (options.searchValue === undefined || options.searchValue.length < 2) {
+            return [];
+        }
+
+        const data = await env.services.orm.call(
+            "web.cmd.search.provider",
+            "cmd_search",
+            [options.searchValue]
+        );
+        const suggestion = [];
+
+        for (const result of data) {
+            suggestion.push({
+                category: "cmd_search",
+                name: result.name,
+                action() {
+                    env.services.action.doAction({
+                        type: "ir.actions.act_window",
+                        res_model: result.model,
+                        res_id: result.id,
+                        views: [[false, "form"]],
+                    });
+                },
+            });
+        }
+
+        return suggestion;
+    },
+});

--- a/web_cmd_search/views/provider.xml
+++ b/web_cmd_search/views/provider.xml
@@ -1,0 +1,40 @@
+<?xml version='1.0' encoding='utf-8' ?>
+<odoo>
+    <record id="view_web_cmd_search_provider_list" model="ir.ui.view">
+        <field name="name">view_web_cmd_search_provider_list</field>
+        <field name="model">web.cmd.search.provider</field>
+        <field name="arch" type="xml">
+            <tree editable="bottom">
+                <field name="sequence" widget="handle" />
+                <field name="model_id" />
+                <field name="limit" />
+            </tree>
+        </field>
+    </record>
+
+    <record
+        id="action_web_cmd_search_provider_act_window"
+        model="ir.actions.act_window"
+    >
+        <field name="name">Command Palette Global Search Provider</field>
+        <field name="res_model">web.cmd.search.provider</field>
+        <field name="view_mode">tree</field>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                No providers found. Let's create one!
+            </p>
+        </field>
+    </record>
+
+    <menuitem
+        id="menu_custom"
+        name="Command Palette Global Search"
+        parent="base.menu_custom"
+    />
+    <menuitem
+        id="menu_custom_provider"
+        name="Provider"
+        parent="menu_custom"
+        action="action_web_cmd_search_provider_act_window"
+    />
+</odoo>


### PR DESCRIPTION
## Description

Adds a configurable global record search to the command palette, using `name_search` to back it

Fixes GH163632

Associated risk level low

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

