### PR TITLE
[FEAT][17.0] report_layout_no_header_no_footer module

### DIFF
--- a/report_layout_no_header_no_footer/README.rst
+++ b/report_layout_no_header_no_footer/README.rst
@@ -1,0 +1,27 @@
+Report Layout No Header No Footer
+=================================
+
+Conditionally hide the header and/or footer in report layouts
+
+Supports all standard report layouts defined in `odoo/addons/web/data/report_layout.xml`
+
+- Bold
+- Boxed
+- Light
+- Striped
+
+Example usage:
+
+.. code-block:: xml
+
+<t t-call="web.external_layout">
+    <t t-set="no_header" t-value="True">
+    <t t-set="no_footer" t-value="True">
+</t>
+
+.. code-block:: xml
+
+<xpath expr="//t[@t-call='web.external_layout']" position="inside">
+    <t t-set="no_header" t-value="True" />
+    <t t-set="no_footer" t-value="True" />
+<xpath>

--- a/report_layout_no_header_no_footer/README.rst
+++ b/report_layout_no_header_no_footer/README.rst
@@ -15,8 +15,8 @@ Example usage:
 .. code-block:: xml
 
 <t t-call="web.external_layout">
-    <t t-set="no_header" t-value="True">
-    <t t-set="no_footer" t-value="True">
+    <t t-set="no_header" t-value="True" />
+    <t t-set="no_footer" t-value="True" />
 </t>
 
 .. code-block:: xml

--- a/report_layout_no_header_no_footer/__manifest__.py
+++ b/report_layout_no_header_no_footer/__manifest__.py
@@ -1,0 +1,9 @@
+{
+    "name": "Report Layout No Header No Footer",
+    "version": "17.0.1.0.0",
+    "author": "Glo Networks",
+    "website": "https://glo.systems",
+    "depends": ["web"],
+    "data": ["views/report_layout"],
+    "license": "LGPL-3",
+}

--- a/report_layout_no_header_no_footer/__manifest__.py
+++ b/report_layout_no_header_no_footer/__manifest__.py
@@ -2,8 +2,8 @@
     "name": "Report Layout No Header No Footer",
     "version": "17.0.1.0.0",
     "author": "Glo Networks",
-    "website": "https://glo.systems",
+    "website": "https://github.com/GlodoUK/odoo-addons",
     "depends": ["web"],
-    "data": ["views/report_layout"],
+    "data": ["views/report_layout.xml"],
     "license": "LGPL-3",
 }

--- a/report_layout_no_header_no_footer/pyproject.toml
+++ b/report_layout_no_header_no_footer/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["whool"]
+build-backend = "whool.buildapi"

--- a/report_layout_no_header_no_footer/views/report_layout.xml
+++ b/report_layout_no_header_no_footer/views/report_layout.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <template id="external_layout_bold" inherit_id="web.external_layout_bold">
+            <xpath expr="//div[contains(@t-attf-class, 'header')]" position="attributes">
+                <attribute name="t-if">not no_header</attribute>
+            </xpath>
+
+            <xpath expr="//div[contains(@t-attf-class, 'footer')]" position="attributes">
+                <attribute name="t-if">not no_footer</attribute>
+            </xpath>
+        </template>
+
+    <template id="external_layout_boxed" inherit_id="web.external_layout_boxed">
+        <xpath expr="//div[contains(@t-attf-class, 'header')]" position="attributes">
+            <attribute name="t-if">not no_header</attribute>
+        </xpath>
+
+        <xpath expr="//div[contains(@t-attf-class, 'footer')]" position="attributes">
+            <attribute name="t-if">not no_footer</attribute>
+        </xpath>
+    </template>
+
+    <template id="external_layout_standard" inherit_id="web.external_layout_standard">
+        <xpath expr="//div[contains(@t-attf-class, 'header')]" position="attributes">
+            <attribute name="t-if">not no_header</attribute>
+        </xpath>
+
+        <xpath expr="//div[contains(@t-attf-class, 'footer')]" position="attributes">
+            <attribute name="t-if">not no_footer</attribute>
+        </xpath>
+    </template>
+
+    <template id="external_layout_striped" inherit_id="web.external_layout_striped">
+        <xpath expr="//div[contains(@t-attf-class, 'header')]" position="attributes">
+            <attribute name="t-if">not no_header</attribute>
+        </xpath>
+
+        <xpath expr="//div[contains(@t-attf-class, 'footer')]" position="attributes">
+            <attribute name="t-if">not no_footer</attribute>
+        </xpath>
+    </template>
+</odoo>

--- a/report_layout_no_header_no_footer/views/report_layout.xml
+++ b/report_layout_no_header_no_footer/views/report_layout.xml
@@ -1,41 +1,65 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <odoo>
     <template id="external_layout_bold" inherit_id="web.external_layout_bold">
-            <xpath expr="//div[contains(@t-attf-class, 'header')]" position="attributes">
+            <xpath
+            expr="//div[contains(@t-attf-class, 'header')]"
+            position="attributes"
+            >
                 <attribute name="t-if">not no_header</attribute>
             </xpath>
 
-            <xpath expr="//div[contains(@t-attf-class, 'footer')]" position="attributes">
+            <xpath
+            expr="//div[contains(@t-attf-class, 'footer')]"
+            position="attributes"
+            >
                 <attribute name="t-if">not no_footer</attribute>
             </xpath>
         </template>
 
     <template id="external_layout_boxed" inherit_id="web.external_layout_boxed">
-        <xpath expr="//div[contains(@t-attf-class, 'header')]" position="attributes">
+        <xpath
+        expr="//div[contains(@t-attf-class, 'header')]"
+        position="attributes"
+        >
             <attribute name="t-if">not no_header</attribute>
         </xpath>
 
-        <xpath expr="//div[contains(@t-attf-class, 'footer')]" position="attributes">
+        <xpath
+        expr="//div[contains(@t-attf-class, 'footer')]"
+        position="attributes"
+        >
             <attribute name="t-if">not no_footer</attribute>
         </xpath>
     </template>
 
     <template id="external_layout_standard" inherit_id="web.external_layout_standard">
-        <xpath expr="//div[contains(@t-attf-class, 'header')]" position="attributes">
+        <xpath
+        expr="//div[contains(@t-attf-class, 'header')]"
+        position="attributes"
+        >
             <attribute name="t-if">not no_header</attribute>
         </xpath>
 
-        <xpath expr="//div[contains(@t-attf-class, 'footer')]" position="attributes">
+        <xpath
+        expr="//div[contains(@t-attf-class, 'footer')]"
+        position="attributes"
+        >
             <attribute name="t-if">not no_footer</attribute>
         </xpath>
     </template>
 
     <template id="external_layout_striped" inherit_id="web.external_layout_striped">
-        <xpath expr="//div[contains(@t-attf-class, 'header')]" position="attributes">
+        <xpath
+        expr="//div[contains(@t-attf-class, 'header')]"
+        position="attributes"
+        >
             <attribute name="t-if">not no_header</attribute>
         </xpath>
 
-        <xpath expr="//div[contains(@t-attf-class, 'footer')]" position="attributes">
+        <xpath
+        expr="//div[contains(@t-attf-class, 'footer')]"
+        position="attributes"
+        >
             <attribute name="t-if">not no_footer</attribute>
         </xpath>
     </template>

--- a/report_layout_no_header_no_footer/views/report_layout.xml
+++ b/report_layout_no_header_no_footer/views/report_layout.xml
@@ -4,62 +4,44 @@
             <xpath
             expr="//div[contains(@t-attf-class, 'header')]"
             position="attributes"
-            >
+        >
                 <attribute name="t-if">not no_header</attribute>
             </xpath>
 
             <xpath
             expr="//div[contains(@t-attf-class, 'footer')]"
             position="attributes"
-            >
+        >
                 <attribute name="t-if">not no_footer</attribute>
             </xpath>
-        </template>
+    </template>
 
     <template id="external_layout_boxed" inherit_id="web.external_layout_boxed">
-        <xpath
-        expr="//div[contains(@t-attf-class, 'header')]"
-        position="attributes"
-        >
+        <xpath expr="//div[contains(@t-attf-class, 'header')]" position="attributes">
             <attribute name="t-if">not no_header</attribute>
         </xpath>
 
-        <xpath
-        expr="//div[contains(@t-attf-class, 'footer')]"
-        position="attributes"
-        >
+        <xpath expr="//div[contains(@t-attf-class, 'footer')]" position="attributes">
             <attribute name="t-if">not no_footer</attribute>
         </xpath>
     </template>
 
     <template id="external_layout_standard" inherit_id="web.external_layout_standard">
-        <xpath
-        expr="//div[contains(@t-attf-class, 'header')]"
-        position="attributes"
-        >
+        <xpath expr="//div[contains(@t-attf-class, 'header')]" position="attributes">
             <attribute name="t-if">not no_header</attribute>
         </xpath>
 
-        <xpath
-        expr="//div[contains(@t-attf-class, 'footer')]"
-        position="attributes"
-        >
+        <xpath expr="//div[contains(@t-attf-class, 'footer')]" position="attributes">
             <attribute name="t-if">not no_footer</attribute>
         </xpath>
     </template>
 
     <template id="external_layout_striped" inherit_id="web.external_layout_striped">
-        <xpath
-        expr="//div[contains(@t-attf-class, 'header')]"
-        position="attributes"
-        >
+        <xpath expr="//div[contains(@t-attf-class, 'header')]" position="attributes">
             <attribute name="t-if">not no_header</attribute>
         </xpath>
 
-        <xpath
-        expr="//div[contains(@t-attf-class, 'footer')]"
-        position="attributes"
-        >
+        <xpath expr="//div[contains(@t-attf-class, 'footer')]" position="attributes">
             <attribute name="t-if">not no_footer</attribute>
         </xpath>
     </template>


### PR DESCRIPTION
## Description

Conditionally hide the header and/or footer in report layouts

Supports all standard report layouts defined in `odoo/addons/web/data/report_layout.xml`

- Bold
- Boxed
- Light
- Striped

ARL: Low

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
