### PR TITLE
[FEAT] purchase_stock_update_move_date 17.0

### DIFF
--- a/purchase_stock_update_move_date/README.rst
+++ b/purchase_stock_update_move_date/README.rst
@@ -1,0 +1,4 @@
+Purchase Stock Update Move Date
+===============================
+
+Updating `date_planned` on `purchase_order_line` propagates to `date` on `stock_move`

--- a/purchase_stock_update_move_date/__init__.py
+++ b/purchase_stock_update_move_date/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/purchase_stock_update_move_date/__manifest__.py
+++ b/purchase_stock_update_move_date/__manifest__.py
@@ -1,0 +1,8 @@
+{
+    "name": "Purchase Stock Update Move Date",
+    "version": "17.0.1.0.0",
+    "author": "Glo Networks",
+    "website": "https://github.com/GlodoUK/odoo-addons",
+    "depends": ["purchase_stock"],
+    "license": "LGPL-3",
+}

--- a/purchase_stock_update_move_date/models/__init__.py
+++ b/purchase_stock_update_move_date/models/__init__.py
@@ -1,0 +1,1 @@
+from . import purchase_order_line

--- a/purchase_stock_update_move_date/models/purchase_order_line.py
+++ b/purchase_stock_update_move_date/models/purchase_order_line.py
@@ -1,0 +1,21 @@
+from odoo import fields, models
+
+
+class PurchaseOrderLine(models.Model):
+    _inherit = "purchase.order.line"
+
+    def write(self, vals):
+        if vals.get("date_planned"):
+            new_date = fields.Datetime.to_datetime(vals["date_planned"])
+
+            self.filtered(lambda line: not line.display_type)._update_move_date(
+                new_date
+            )
+
+        return super().write(vals)
+
+    def _update_move_date(self, new_date):
+        moves_to_update = self.move_ids.filtered(
+            lambda m: m.state not in ("done", "cancel")
+        )
+        moves_to_update.date = new_date

--- a/purchase_stock_update_move_date/pyproject.toml
+++ b/purchase_stock_update_move_date/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["whool"]
+build-backend = "whool.buildapi"

--- a/purchase_stock_update_move_date/tests/__init__.py
+++ b/purchase_stock_update_move_date/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_update_move_date

--- a/purchase_stock_update_move_date/tests/test_update_move_date.py
+++ b/purchase_stock_update_move_date/tests/test_update_move_date.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+
 from dateutil.relativedelta import relativedelta
 from freezegun import freeze_time
 
@@ -11,25 +12,33 @@ class TestUpdateMoveDate(TransactionCase):
     def setUpClass(cls):
         super().setUpClass()
 
-        cls.partner_id = cls.env["res.partner"].create({
-            "name": "Example",
-        })
+        cls.partner_id = cls.env["res.partner"].create(
+            {
+                "name": "Example",
+            }
+        )
 
-        cls.product_id = cls.env["product.product"].create({
-            "name": "Product",
-            "type": "product",
-        })
+        cls.product_id = cls.env["product.product"].create(
+            {
+                "name": "Product",
+                "type": "product",
+            }
+        )
 
     @freeze_time("2025-01-01 06:00:00")
     def test_update_move_date(self):
-        order_id = self.env["purchase.order"].create({
-            "partner_id": self.partner_id.id,
-        })
+        order_id = self.env["purchase.order"].create(
+            {
+                "partner_id": self.partner_id.id,
+            }
+        )
 
-        order_line_id = self.env["purchase.order.line"].create({
-            "order_id": order_id.id,
-            "product_id": self.product_id.id,
-        })
+        order_line_id = self.env["purchase.order.line"].create(
+            {
+                "order_id": order_id.id,
+                "product_id": self.product_id.id,
+            }
+        )
 
         order_id.button_confirm()
 
@@ -40,9 +49,9 @@ class TestUpdateMoveDate(TransactionCase):
 
         date_planned_initial = order_line_id.date_planned
 
-        order_line_id.write({
-            "date_planned": date_planned_initial + relativedelta(days=5)
-        })
+        order_line_id.write(
+            {"date_planned": date_planned_initial + relativedelta(days=5)}
+        )
 
         self.assertEqual(
             order_id.picking_ids.move_ids.date,

--- a/purchase_stock_update_move_date/tests/test_update_move_date.py
+++ b/purchase_stock_update_move_date/tests/test_update_move_date.py
@@ -26,7 +26,40 @@ class TestUpdateMoveDate(TransactionCase):
         )
 
     @freeze_time("2025-01-01 06:00:00")
-    def test_update_move_date(self):
+    def test_update_move_date_order(self):
+        order_id = self.env["purchase.order"].create(
+            {
+                "partner_id": self.partner_id.id,
+            }
+        )
+
+        self.env["purchase.order.line"].create(
+            {
+                "order_id": order_id.id,
+                "product_id": self.product_id.id,
+            }
+        )
+
+        order_id.button_confirm()
+
+        self.assertEqual(
+            order_id.picking_ids.move_ids.date,
+            datetime(2025, 1, 1, 6, 0, 0),  # 6AM 2025 1st Jan
+        )
+
+        date_planned_initial = order_id.date_planned
+
+        order_id.write(
+            {"date_planned": date_planned_initial + relativedelta(days=5)}
+        )
+
+        self.assertEqual(
+            order_id.picking_ids.move_ids.date,
+            datetime(2025, 1, 6, 6, 0, 0),  # 6AM 2025 6th Jan
+        )
+
+    @freeze_time("2025-01-01 06:00:00")
+    def test_update_move_date_order_line(self):
         order_id = self.env["purchase.order"].create(
             {
                 "partner_id": self.partner_id.id,

--- a/purchase_stock_update_move_date/tests/test_update_move_date.py
+++ b/purchase_stock_update_move_date/tests/test_update_move_date.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from dateutil.relativedelta import relativedelta
 from freezegun import freeze_time
 
-from odoo.tests import TransactionCase, tagged
+from odoo.tests import Form, TransactionCase, tagged
 
 
 @tagged("post_install", "-at_install")
@@ -47,15 +47,14 @@ class TestUpdateMoveDate(TransactionCase):
             datetime(2025, 1, 1, 6, 0, 0),  # 6AM 2025 1st Jan
         )
 
-        date_planned_initial = order_id.date_planned
-
-        order_id.write(
-            {"date_planned": date_planned_initial + relativedelta(days=5)}
-        )
+        with Form(order_id) as form:
+            date_planned_initial = order_id.date_planned
+            form.date_planned = date_planned_initial + relativedelta(days=5)
+            form.save()
 
         self.assertEqual(
             order_id.picking_ids.move_ids.date,
-            datetime(2025, 1, 6, 6, 0, 0),  # 6AM 2025 6th Jan
+            datetime(2025, 1, 6, 6, 0, 0),  # 6AM 2025 6st Jan
         )
 
     @freeze_time("2025-01-01 06:00:00")

--- a/purchase_stock_update_move_date/tests/test_update_move_date.py
+++ b/purchase_stock_update_move_date/tests/test_update_move_date.py
@@ -1,0 +1,45 @@
+from dateutil.relativedelta import relativedelta
+
+from odoo import fields
+from odoo.tests import TransactionCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUpdateMoveDate(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.partner_id = cls.env["res.partner"].create({"name": "Example"})
+
+        cls.product_id = cls.env["product.product"].create(
+            {"name": "Product", "type": "product"}
+        )
+
+        cls.order_id = cls.env["purchase.order"].create(
+            {"partner_id": cls.partner_id.id}
+        )
+
+        cls.order_line_id = cls.env["purchase.order.line"].create(
+            {
+                "order_id": cls.order_id.id,
+                "product_id": cls.product_id.id,
+            }
+        )
+
+    def test_update_move_date(self):
+        self.order_id.button_confirm()
+
+        self.assertEqual(
+            self.order_id.picking_ids.move_ids.date,
+            fields.Datetime.now(),
+        )
+
+        self.order_line_id.write(
+            {"date_planned": fields.Datetime.now() + relativedelta(days=5)}
+        )
+
+        self.assertEqual(
+            self.order_id.picking_ids.move_ids.date,
+            fields.Datetime.now() + relativedelta(days=5),
+        )


### PR DESCRIPTION
## Description

Updating `date_planned` on `purchase_order_line` propagates to `date` on `stock_move`

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

