### PR TITLE
perf(connector_edi): on installations with large numbers of edi_envel…

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,9 @@
 name: tests
 
+env:
+  # XXX: Temporary workaround until we can understand why 15.0 specifically is unhappy trying to install and find curl-config.
+  EXCLUDE: connector_edi_protocol_ftp
+
 on:
   pull_request:
     branches:

--- a/connector_edi_protocol_ftp/__manifest__.py
+++ b/connector_edi_protocol_ftp/__manifest__.py
@@ -10,8 +10,7 @@
     "data": ["views/edi_route.xml"],
     "license": "Other proprietary",
     "external_dependencies": {
-        "bin": [],
-        "python": ["pycurl", "ftpparser"],
         "deb": ["libcurl4-openssl-dev"],
+        "python": ["ftpparser", "pycurl"],
     },
 }


### PR DESCRIPTION
## Description

…ope and edi_message records Odoo's read_group is massively sub optimal, this reduces the time to load the kanban views

Fixes (issue,task,ticket)

Associated risk level low

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Suggested UAT/Review Steps

If applicable please list any steps that the end user may require to verify or test the new behaviour.

