### PR TITLE
[18.0][T14187] concurrency_warning

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -136,3 +136,7 @@ repos:
       - id: pylint_odoo
         args:
           - --rcfile=.pylintrc-mandatory
+  - repo: https://github.com/rstcheck/rstcheck.git
+    rev: v6.2.4
+    hooks:
+      - id: rstcheck

--- a/concurrency_warning/README.rst
+++ b/concurrency_warning/README.rst
@@ -1,0 +1,72 @@
+-------------------
+concurrency_warning
+-------------------
+
+When a user is viewing a record within the Odoo backend web UI, and the record
+is changed, when configured the system will notify the user that the record has
+changed and (optionally) reload the record.
+
+Additional configuration is required per-model to enable this feature. This is
+by design to ensure that we do not effectively spam the user about records they
+do not care about.
+
+Example usage
+--------------
+
+::
+
+    <record id="poke_sale_order_on_write" model="base.automation">
+      <field name="name">Poke on Sale Order Change</field>
+      <field name="model_id" ref="sale.model_sale_order"/>
+      <field name="state">poke</field>
+      <field name="trigger">on_write</field>
+    </record>
+
+    <record id="poke_purchase_order_on_write" model="base.automation">
+      <field name="name">Poke on Purchase Order Change</field>
+      <field name="model_id" ref="purchase.model_purchase_order"/>
+      <field name="state">poke</field>
+      <field name="trigger">on_write</field>
+    </record>
+
+
+Notes on the implementation
+---------------------------
+
+This module works on a broadcast system (limited to internal users).
+Over the bus.bus websocket. This is obviously problematic for at least 2 reasons:
+
+1. Potentially exposes (limited) information to users who should not see things
+2. It's just wasteful
+
+In an ideal world we would join and leave channels based on the currently viewed record.
+
+In practice this leaves a few problems:
+
+1. The bus doesn't actually differentiate the channel on the javascript side (when you
+   subscribe to an event from the bus service). Meaning that you still need to verify
+   the currently viewed record anyway!
+
+2. If you attempt to join and leave channels (imagine 1 dynamic channel per record),
+   when you rejoin you receive stale records from upto 50 seconds ago. Considering that
+   the "pokes" are emphemeral this is problematic.
+
+3. Hooking into FormController it's actually properly fiddly to know when you're viewing
+   a new record and leaving. There's a lot of nuance (in at least 18) about when
+   OnWillLoadRoot, OnWillUnmount, destroy, etc. are all called.
+   We'd also need to duplicate this for other things like FormController.
+
+Potential solutions:
+
+1. Current implementation.
+
+2. A lot of super'ing in the bus module to support completely emphermal messages.
+   Practically this would be unwise as we'd need to completely replace several methods.
+
+3. A new endpoint, like /websocket. Practically that would be problematic to run outside
+   of certain hosting environments.
+
+4. Allow all models to have their own channels. They need to placed onto an allow-list
+   explicitly, meaning lots of glue modules, breaking backwards compatibility.
+
+5. ??

--- a/concurrency_warning/README.rst
+++ b/concurrency_warning/README.rst
@@ -11,7 +11,7 @@ by design to ensure that we do not effectively spam the user about records they
 do not care about.
 
 Example usage
---------------
+-------------
 
 ::
 

--- a/concurrency_warning/README.rst
+++ b/concurrency_warning/README.rst
@@ -36,37 +36,36 @@ Notes on the implementation
 This module works on a broadcast system (limited to internal users).
 Over the bus.bus websocket. This is obviously problematic for at least 2 reasons:
 
-1. Potentially exposes (limited) information to users who should not see things
-2. It's just wasteful
+#. Potentially exposes (limited) information to users who should not see things
+
+#. It's just wasteful
 
 In an ideal world we would join and leave channels based on the currently viewed record.
 
 In practice this leaves a few problems:
 
-1. The bus doesn't actually differentiate the channel on the javascript side (when you
+#. The bus doesn't actually differentiate the channel on the javascript side (when you
    subscribe to an event from the bus service). Meaning that you still need to verify
    the currently viewed record anyway!
 
-2. If you attempt to join and leave channels (imagine 1 dynamic channel per record),
+#. If you attempt to join and leave channels (imagine 1 dynamic channel per record),
    when you rejoin you receive stale records from upto 50 seconds ago. Considering that
    the "pokes" are emphemeral this is problematic.
 
-3. Hooking into FormController it's actually properly fiddly to know when you're viewing
+#. Hooking into FormController it's actually properly fiddly to know when you're viewing
    a new record and leaving. There's a lot of nuance (in at least 18) about when
    OnWillLoadRoot, OnWillUnmount, destroy, etc. are all called.
    We'd also need to duplicate this for other things like FormController.
 
 Potential solutions:
 
-1. Current implementation.
+#. Current implementation.
 
-2. A lot of super'ing in the bus module to support completely emphermal messages.
-   Practically this would be unwise as we'd need to completely replace several methods.
+#. A lot of super'ing in the bus module to support completely emphermal messages.
+Practically this would be unwise as we'd need to completely replace several methods.
 
-3. A new endpoint, like /websocket. Practically that would be problematic to run outside
+#. A new endpoint, like /websocket. Practically that would be problematic to run outside
    of certain hosting environments.
 
-4. Allow all models to have their own channels. They need to placed onto an allow-list
+#. Allow all models to have their own channels. They need to placed onto an allow-list
    explicitly, meaning lots of glue modules, breaking backwards compatibility.
-
-5. ??

--- a/concurrency_warning/__init__.py
+++ b/concurrency_warning/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/concurrency_warning/__manifest__.py
+++ b/concurrency_warning/__manifest__.py
@@ -1,0 +1,23 @@
+{
+    "name": "concurrency_warning",
+    "summary": "Issue a visual warning and reload the page content if a user"
+    " has left a model open, and it been altered in the meantime.",
+    "author": "Glo Networks",
+    "website": "https://github.com/GlodoUK/odoo-addons",
+    "category": "Uncategorized",
+    "version": "18.0.1.0.0",
+    "depends": [
+        "bus",
+        "base",
+    ],
+    "data": [
+        "views/ir_actions_server.xml",
+    ],
+    "demo": [],
+    "license": "LGPL-3",
+    "assets": {
+        "web.assets_backend": [
+            "/concurrency_warning/static/src/js/poke_service.esm.js"
+        ],
+    },
+}

--- a/concurrency_warning/models/__init__.py
+++ b/concurrency_warning/models/__init__.py
@@ -1,0 +1,2 @@
+from . import ir_actions_server
+from . import ir_websocket

--- a/concurrency_warning/models/ir_actions_server.py
+++ b/concurrency_warning/models/ir_actions_server.py
@@ -1,0 +1,53 @@
+from odoo import fields, models
+
+
+class IrActionsServer(models.Model):
+    _inherit = "ir.actions.server"
+
+    state = fields.Selection(
+        selection_add=[("poke", "Prompt user that record has changed")],
+        ondelete={"poke": "cascade"},
+    )
+    poke_msg = fields.Text(
+        default="This record has been changed by another user since you opened" " it.",
+        string="Message",
+    )
+    poke_refresh = fields.Boolean(default=True, string="Automatically refresh")
+    poke_sticky = fields.Boolean(default=False, string="Sticky notification")
+    poke_type = fields.Selection(
+        [
+            ("info", "Info"),
+            ("warning", "Warning"),
+            ("danger", "Danger"),
+            ("success", "Success"),
+        ],
+        default="warning",
+    )
+
+    def _run_action_poke_multi(self, eval_context=None):
+        if eval_context is None:
+            eval_context = {}
+
+        records = eval_context.get("records") or eval_context.get("record")
+        if not records:
+            return False
+
+        records = records.filtered(lambda r: not isinstance(r.id, models.NewId))
+        if not records:
+            return False
+
+        for record in records:
+            self.env["bus.bus"]._sendone(
+                "poke",
+                "poke/live_update",
+                {
+                    "type": self.poke_type,
+                    "message": self.poke_msg,
+                    "refresh": self.poke_refresh,
+                    "resId": record.id,
+                    "resModel": record._name,
+                    "userId": self.env.uid,
+                    "sticky": self.poke_sticky,
+                },
+            )
+        return False

--- a/concurrency_warning/models/ir_websocket.py
+++ b/concurrency_warning/models/ir_websocket.py
@@ -1,0 +1,11 @@
+from odoo import models
+
+
+class IrWebSocket(models.AbstractModel):
+    _inherit = "ir.websocket"
+
+    def _build_bus_channel_list(self, channels):
+        res = super()._build_bus_channel_list(channels)
+        if self.env.user._is_internal():
+            res.append("poke")
+        return res

--- a/concurrency_warning/pyproject.toml
+++ b/concurrency_warning/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["whool"]
+build-backend = "whool.buildapi"

--- a/concurrency_warning/static/src/js/poke_service.esm.js
+++ b/concurrency_warning/static/src/js/poke_service.esm.js
@@ -1,0 +1,49 @@
+import {_t} from "@web/core/l10n/translation";
+import {debounce} from "@web/core/utils/timing";
+import {registry} from "@web/core/registry";
+import {user} from "@web/core/user";
+
+export const concurrencyWarningService = {
+    dependencies: ["bus_service", "notification", "action"],
+
+    start(_env, {bus_service, notification: notification_service, action}) {
+        const notify = (notification) => {
+            const controller = action.currentController;
+            if (notification.userId === user.userId) {
+                return;
+            }
+            const viewing =
+                controller?.props?.resModel === notification.resModel &&
+                controller?.props?.resId === notification.resId;
+            if (!viewing) {
+                return;
+            }
+
+            const delNotification = notification_service.add(notification.message, {
+                type: notification.type,
+                sticky: notification.sticky || !notification.refresh,
+                buttons: notification.refresh
+                    ? undefined
+                    : [
+                          {
+                              name: _t("Refresh"),
+                              primary: true,
+                              onClick: async () => {
+                                  await action.doAction("soft_reload");
+                                  delNotification();
+                              },
+                          },
+                      ],
+            });
+
+            // Soft_reload
+            if (notification.refresh) {
+                action.doAction("soft_reload");
+            }
+        };
+        bus_service.subscribe("poke/live_update", debounce(notify, 1000, true));
+        bus_service.start();
+    },
+};
+
+registry.category("services").add("concurrencyWarning", concurrencyWarningService);

--- a/concurrency_warning/views/ir_actions_server.xml
+++ b/concurrency_warning/views/ir_actions_server.xml
@@ -1,0 +1,17 @@
+<odoo>
+    <record model="ir.ui.view" id="view_server_action_form">
+        <field name="name">view_server_action_form</field>
+        <field name="model">ir.actions.server</field>
+        <field name="inherit_id" ref="base.view_server_action_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//group[@name='action_content']" position="inside">
+                <group invisible="state != 'poke'">
+                    <field name="poke_msg" />
+                    <field name="poke_refresh" />
+                    <field name="poke_type" />
+                    <field name="poke_sticky" />
+                </group>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Port `concurrency_warning` to 18.0.

I've spent an inordinate amount of time over the last evening thinking about this, trying to improve it. I don't think we can practically. I have left notes.

Fixes T14187

**ARL (Associated Risk Level):**
- [x] Low
- [ ] Medium
- [ ] High

**Type of change:**
- [x] Upgrade/Version migration
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

