### PR TITLE
fix(connector_edi,connector_edi_sale,connector_edi_stock): support connector_no_export

### DIFF
--- a/connector_edi/components/envelope_listener.py
+++ b/connector_edi/components/envelope_listener.py
@@ -6,7 +6,17 @@ class EdiEnvelopeListener(Component):
     _inherit = "base.event.listener"
     _apply_on = ["edi.envelope"]
 
+    def no_connector_export(self, record):
+        # FIXME: duplicated because we've inherited off base.event.listener rather than
+        # base.connector.listener.
+        return record.env.context.get("no_connector_export") or record.env.context.get(
+            "connector_no_export"
+        )
+
     def on_pending(self, record):
+        if self.no_connector_export(record):
+            return
+
         if record.direction == "in":
             opts = {}
             if record.route_id:

--- a/connector_edi/components/message_listener.py
+++ b/connector_edi/components/message_listener.py
@@ -6,7 +6,17 @@ class EdiMessageListener(Component):
     _inherit = "base.event.listener"
     _apply_on = ["edi.message"]
 
+    def no_connector_export(self, record):
+        # FIXME: duplicated because we've inherited off base.event.listener rather than
+        # base.connector.listener.
+        return record.env.context.get("no_connector_export") or record.env.context.get(
+            "connector_no_export"
+        )
+
     def on_pending(self, record):
+        if self.no_connector_export(record):
+            return
+
         if record.direction == "in" and record.state == "pending":
             opts = {}
             if record.message_route_id:

--- a/connector_edi_product/components/product_listener.py
+++ b/connector_edi_product/components/product_listener.py
@@ -9,8 +9,18 @@ class ProductTemplateListener(Component):
     _inherit = "base.event.listener"
     _apply_on = ["product.template"]
 
+    def no_connector_export(self, record):
+        # FIXME: duplicated because we've inherited off base.event.listener rather than
+        # base.connector.listener.
+        return record.env.context.get("no_connector_export") or record.env.context.get(
+            "connector_no_export"
+        )
+
     def on_record_write_edi(self, records, fields=None):
         for record in records:
+            if self.no_connector_export(record):
+                continue
+
             edi_product_id = record.edi_product_tmpl_ids
 
             if not edi_product_id:
@@ -57,6 +67,9 @@ class ProductTemplateListener(Component):
             return
         for route in routes:
             for record in records:
+                if self.no_connector_export(record):
+                    continue
+
                 route.sudo().send_messages_using_first_match(
                     route.backend_id,
                     record,
@@ -79,8 +92,17 @@ class ProductProductListener(Component):
     _inherit = "base.event.listener"
     _apply_on = ["product.product"]
 
+    def no_connector_export(self, record):
+        # FIXME: duplicated because we've inherited off base.event.listener rather than
+        # base.connector.listener.
+        return record.env.context.get("no_connector_export") or record.env.context.get(
+            "connector_no_export"
+        )
+
     def on_record_write_edi(self, records, fields=None):
         for record in records:
+            if self.no_connector_export(record):
+                continue
             edi_product_id = record.edi_product_ids
 
             if not edi_product_id:
@@ -125,6 +147,8 @@ class ProductProductListener(Component):
             return
         for route in routes:
             for record in records:
+                if self.no_connector_export(record):
+                    continue
                 route.sudo().send_messages_using_first_match(
                     route.backend_id,
                     record,

--- a/connector_edi_sale/components/account_invoice_listener.py
+++ b/connector_edi_sale/components/account_invoice_listener.py
@@ -9,7 +9,17 @@ class AccountInvoiceListener(Component):
     _inherit = "base.event.listener"
     _apply_on = ["account.move"]
 
+    def no_connector_export(self, record):
+        # FIXME: duplicated because we've inherited off base.event.listener rather than
+        # base.connector.listener.
+        return record.env.context.get("no_connector_export") or record.env.context.get(
+            "connector_no_export"
+        )
+
     def on_out_invoice_open(self, record):
+        if self.no_connector_export(record):
+            return
+
         edi_sale_id = record.sudo().mapped(
             "invoice_line_ids.sale_line_ids.order_id.edi_sale_order_ids"
         )

--- a/connector_edi_sale/components/stock_picking_listener.py
+++ b/connector_edi_sale/components/stock_picking_listener.py
@@ -6,7 +6,17 @@ class StockPickingListener(Component):
     _inherit = "base.event.listener"
     _apply_on = ["stock.picking"]
 
+    def no_connector_export(self, record):
+        # FIXME: duplicated because we've inherited off base.event.listener rather than
+        # base.connector.listener.
+        return record.env.context.get("no_connector_export") or record.env.context.get(
+            "connector_no_export"
+        )
+
     def on_picking_out_done(self, record, completed):
+        if self.no_connector_export(record):
+            return
+
         for backend_id in record.sudo().sale_id.mapped("edi_sale_order_ids.backend_id"):
             self.env["edi.route"].sudo().send_messages_using_first_match(
                 backend_id,

--- a/connector_edi_stock/components/stock.py
+++ b/connector_edi_stock/components/stock.py
@@ -6,7 +6,17 @@ class StockPickingListener(Component):
     _inherit = "base.event.listener"
     _apply_on = ["stock.picking"]
 
+    def no_connector_export(self, record):
+        # FIXME: duplicated because we've inherited off base.event.listener rather than
+        # base.connector.listener.
+        return record.env.context.get("no_connector_export") or record.env.context.get(
+            "connector_no_export"
+        )
+
     def on_picking_in_cancel(self, record, completed=False):
+        if self.no_connector_export(record):
+            return
+
         for backend_id in record.sudo().sale_id.mapped("edi_sale_order_ids.backend_id"):
             self.env["edi.route"].sudo().send_messages_using_first_match(
                 backend_id,
@@ -25,6 +35,9 @@ class StockPickingListener(Component):
             )
 
     def on_picking_out_cancel(self, record, completed=False):
+        if self.no_connector_export(record):
+            return
+
         for backend_id in record.sudo().sale_id.mapped("edi_sale_order_ids.backend_id"):
             self.env["edi.route"].sudo().send_messages_using_first_match(
                 backend_id,
@@ -43,6 +56,9 @@ class StockPickingListener(Component):
             )
 
     def on_picking_assigned(self, record, completed=False):
+        if self.no_connector_export(record):
+            return
+
         for backend_id in record.sudo().sale_id.mapped("edi_sale_order_ids.backend_id"):
             self.env["edi.route"].sudo().send_messages_using_first_match(
                 backend_id,
@@ -61,6 +77,9 @@ class StockPickingListener(Component):
             )
 
     def on_picking_unreserved(self, record, completed=False):
+        if self.no_connector_export(record):
+            return
+
         for backend_id in record.sudo().sale_id.mapped("edi_sale_order_ids.backend_id"):
             self.env["edi.route"].sudo().send_messages_using_first_match(
                 backend_id,
@@ -84,7 +103,17 @@ class StockMoveListener(Component):
     _inherit = "base.event.listener"
     _apply_on = ["stock.move"]
 
+    def no_connector_export(self, record):
+        # FIXME: duplicated because we've inherited off base.event.listener rather than
+        # base.connector.listener.
+        return record.env.context.get("no_connector_export") or record.env.context.get(
+            "connector_no_export"
+        )
+
     def on_move_done(self, record, completed=False):
+        if self.no_connector_export(record):
+            return
+
         route_domain = [
             ("action_trigger", "=", "model_event"),
             (
@@ -101,6 +130,9 @@ class StockMoveListener(Component):
             )
 
     def on_move_reserved_changed(self, record, completed=False):
+        if self.no_connector_export(record):
+            return
+
         route_domain = [
             ("action_trigger", "=", "model_event"),
             (


### PR DESCRIPTION
Embarrassingly we don't support connector_no_export, and worse than that, we've actually inherited too low.

For safety, I've added the check rather than changing what the listeners inherit from.

Required for performance reasons in a fix up script we're writing for a customer's mangled stock journals.

**Dependencies:**
- N/A

**ARL (Associated Risk Level):**
- [ ] Low
- [x] Medium
- [ ] High

**Type of change:**
- [ ] Forwardport / Backport
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

