### PR TITLE
[18.0][IMP] res_partner_bank_display_format

### DIFF
--- a/res_partner_bank_display_format/README.rst
+++ b/res_partner_bank_display_format/README.rst
@@ -1,0 +1,12 @@
+===============================
+res_partner_bank_display_format
+===============================
+
+Allows for res.partner.bank's display name to be customised in a similar fashion to
+res.company address formatting.
+
+Useful to help reformat a bank account to regional standards, on a per-bank account
+basis.
+
+Very useful for UK markets to reformat accounts in invoices.
+

--- a/res_partner_bank_display_format/__init__.py
+++ b/res_partner_bank_display_format/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/res_partner_bank_display_format/__manifest__.py
+++ b/res_partner_bank_display_format/__manifest__.py
@@ -1,0 +1,13 @@
+{
+    "name": "res_partner_bank_display_format",
+    "summary": "Customise the format of the partner bank",
+    "author": "Glo Networks",
+    "website": "https://github.com/GlodoUK/odoo-addons",
+    "category": "Uncategorized",
+    "version": "18.0.1.0.0",
+    "depends": ["account"],
+    "data": [
+        "views/res_partner_bank.xml",
+    ],
+    "license": "LGPL-3",
+}

--- a/res_partner_bank_display_format/models/__init__.py
+++ b/res_partner_bank_display_format/models/__init__.py
@@ -1,0 +1,1 @@
+from . import res_partner_bank

--- a/res_partner_bank_display_format/models/res_partner_bank.py
+++ b/res_partner_bank_display_format/models/res_partner_bank.py
@@ -1,0 +1,84 @@
+import logging
+import re
+
+from odoo import _, api, fields, models
+
+_logger = logging.getLogger(__file__)
+
+
+class ResPartnerBank(models.Model):
+    _inherit = "res.partner.bank"
+
+    custom_display_name_format = fields.Text(
+        string="Custom Display Name",
+        help="Custom Display format to use for this address. Useful to reformat a bank"
+        "account for a specific region without making lots of manual changes to invoice"
+        "documents.\n\n"
+        "You can use python-style string pattern"
+        "(for example, use '%(acc_number)s' to display the field 'account number') plus"
+        "\n%(bank_name)s: the name of the bank"
+        "\n%(bank_bic)s: the bank identifier code",
+        default=False,
+        required=False,
+    )
+
+    custom_display_name_format_warning = fields.Char(
+        compute="_compute_custom_display_name_format_warning"
+    )
+
+    def _get_custom_display_name_format_values(self):
+        self.ensure_one()
+        return {
+            "acc_number": self.acc_number or "",
+            "bank_name": self.bank_id.name or "",
+            "bank_bic": self.bank_bic or "",
+            "bank_street": self.bank_id.street or "",
+            "bank_street2": self.bank_id.street2 or "",
+            "bank_city": self.bank_id.city or "",
+            "bank_state": self.bank_id.state.name or "",
+            "bank_country": self.bank_id.country.name or "",
+            "bank_country_code": self.bank_id.country.code or "",
+            "bank_zip": self.bank_id.zip or "",
+            "currency_name": self.currency_id.name or "",
+            "currency_full_name": self.currency_id.full_name or "",
+            "partner_display_name": self.partner_id.display_name or "",
+        }
+
+    @api.depends("custom_display_name_format")
+    def _compute_custom_display_name_format_warning(self):
+        for record in self:
+            if not record.custom_display_name_format:
+                record.custom_display_name_format_warning = False
+                continue
+
+            try:
+                _res = record._get_custom_display_name_format()
+                record.custom_display_name_format_warning = False
+            except KeyError as e:
+                record.custom_display_name_format_warning = str(e)
+
+    def _get_custom_display_name_format(self):
+        self.ensure_one()
+        name = (
+            self.custom_display_name_format
+            % self._get_custom_display_name_format_values()
+        )
+        if self.env.context.get("display_account_trust"):
+            trusted_label = _("trusted") if self.allow_out_payment else _("untrusted")
+            name = f"{name} {trusted_label}"
+        name = re.sub(r"\s\s+", " ", name)
+        return name
+
+    @api.depends("custom_display_name_format")
+    @api.depends_context("display_account_trust")
+    def _compute_display_name(self):
+        res = super()._compute_display_name()
+
+        for record in self.filtered(lambda x: x.custom_display_name_format):
+            try:
+                record.display_name = record._get_custom_display_name_format()
+            except KeyError as e:
+                _logger.warning("Failed to compute custom display name", e)
+                pass
+
+        return res

--- a/res_partner_bank_display_format/pyproject.toml
+++ b/res_partner_bank_display_format/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["whool"]
+build-backend = "whool.buildapi"

--- a/res_partner_bank_display_format/tests/__init__.py
+++ b/res_partner_bank_display_format/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_custom_display_name_format

--- a/res_partner_bank_display_format/tests/test_custom_display_name_format.py
+++ b/res_partner_bank_display_format/tests/test_custom_display_name_format.py
@@ -1,0 +1,75 @@
+from odoo.tests import TransactionCase
+
+
+class TestCustomDisplayNameFormat(TransactionCase):
+    def setUp(self):
+        super().setUp()
+        self.bank_id = self.env["res.bank"].create(
+            {
+                "name": "Test123",
+                "bic": "456",
+                "street": "street1",
+                "street2": "street2",
+                "city": "city",
+                "zip": "zip",
+            }
+        )
+
+        self.res_partner_bank_id = self.env["res.partner.bank"].create(
+            {
+                "bank_id": self.bank_id.id,
+                "acc_number": "ACC#1",
+                "partner_id": self.env.company.partner_id.id,
+                "custom_display_name_format": (
+                    "TESTY TEST %(acc_number)s %(bank_name)s %(bank_street)s"
+                    " %(bank_street2)s %(bank_city)s %(bank_zip)s"
+                ),
+            }
+        )
+
+    def test_custom_format(self):
+        self.assertEqual(
+            "TESTY TEST ACC#1 Test123 street1 street2 city zip",
+            self.res_partner_bank_id.display_name,
+        )
+        self.assertFalse(self.res_partner_bank_id.custom_display_name_format_warning)
+
+    def test_trim_double_spaces(self):
+        self.res_partner_bank_id.acc_number = False
+        self.res_partner_bank_id.custom_display_name_format = (
+            "TESTY TEST    %(acc_number)s %(bank_name)s"
+        )
+
+        self.assertEqual("TESTY TEST Test123", self.res_partner_bank_id.display_name)
+        self.assertFalse(self.res_partner_bank_id.custom_display_name_format_warning)
+
+    def test_recover_from_keyerror(self):
+        self.res_partner_bank_id.acc_number = False
+        self.res_partner_bank_id.custom_display_name_format = (
+            "TESTY TEST    %(acc_number)s %(bank_name)s %(unknown)s"
+        )
+
+        self.assertEqual("False - Test123", self.res_partner_bank_id.display_name)
+        self.assertTrue(
+            len(self.res_partner_bank_id.custom_display_name_format_warning) > 0
+        )
+
+    def test_trusted_untrusted(self):
+        self.res_partner_bank_id.custom_display_name_format = "%(acc_number)s"
+
+        self.assertEqual(
+            "ACC#1 untrusted",
+            self.res_partner_bank_id.with_context(
+                display_account_trust=True
+            ).display_name,
+        )
+
+        self.res_partner_bank_id.allow_out_payment = True
+
+        self.assertEqual(
+            "ACC#1 trusted",
+            self.res_partner_bank_id.with_context(
+                display_account_trust=True
+            ).display_name,
+        )
+        self.assertFalse(self.res_partner_bank_id.custom_display_name_format_warning)

--- a/res_partner_bank_display_format/views/res_partner_bank.xml
+++ b/res_partner_bank_display_format/views/res_partner_bank.xml
@@ -1,0 +1,20 @@
+<?xml version='1.0' encoding='utf-8' ?>
+<odoo>
+    <record id="view_partner_bank_form" model="ir.ui.view">
+        <field name="name">view_partner_bank_form</field>
+        <field name="model">res.partner.bank</field>
+        <field name="inherit_id" ref="base.view_partner_bank_form" />
+        <field name="priority">99</field>
+        <field name="arch" type="xml">
+            <xpath expr="//sheet/group" position="inside">
+                <group colspan="2">
+                    <field name="custom_display_name_format" />
+                    <field
+                        name="custom_display_name_format_warning"
+                        invisible="not custom_display_name_format_warning"
+                    />
+                </group>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
New module to allow the res.partner.bank display name to be overridden in a similar way to res.company address formatting. Useful for UK markets.

**Dependencies:**
- N/A

**ARL (Associated Risk Level):**
- [x] Low
- [ ] Medium
- [ ] High

**Type of change:**
- [ ] Forwardport / Backport
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

