### PR TITLE
fix(helpdesk_privacy): ensure that we do not subscribe users who do not already follow the ticket when processing a message_update.

### DIFF
--- a/brands/views/report_templates/external_layout_bold.xml
+++ b/brands/views/report_templates/external_layout_bold.xml
@@ -18,7 +18,7 @@
                 />
             </t>
         </xpath>
-        <xpath expr="//strong[@t-if='company.report_header']" position="replace">
+        <xpath expr="//strong[@t-field='company.report_header']" position="replace">
             <t
                 t-set="header_tagline"
                 t-value="o and 'brand_id' in o and o.brand_id and o.brand_id.report_header or company.report_header"

--- a/brands/views/report_templates/external_layout_boxed.xml
+++ b/brands/views/report_templates/external_layout_boxed.xml
@@ -18,7 +18,7 @@
                 />
             </t>
         </xpath>
-        <xpath expr="//strong[@t-if='company.report_header']" position="replace">
+        <xpath expr="//strong[@t-field='company.report_header']" position="replace">
             <t
                 t-set="header_tagline"
                 t-value="o and 'brand_id' in o and o.brand_id and o.brand_id.report_header or company.report_header"

--- a/helpdesk_privacy/models/helpdesk_ticket.py
+++ b/helpdesk_privacy/models/helpdesk_ticket.py
@@ -25,3 +25,43 @@ class HelpdeskTicket(models.Model):
             ("id", "child_of", self.commercial_partner_id.id),
             ("id", "not in", self.message_partner_ids.ids),
         ]
+
+    def message_update(self, msg, update_vals=None):
+        return super(
+            HelpdeskTicket,
+            self.with_context(
+                helpdesk_privacy_only_subscribe_existing_partners=self.is_private
+            ),
+        ).message_update(msg, update_vals=update_vals)
+
+    def _message_subscribe(self, partner_ids=None, subtype_ids=None, customer_ids=None):
+        """
+        Override to enforce privacy and prevent users from subscribing to tickets
+        that they should not have access to.
+
+        This can be achieved by unauthorised user responding to an email with Odoo
+        headers on it. i.e. it is forwarded to them by someone who does have access.
+
+        This is not a perfect implementation, but I'm unclear how to better handle
+        better without a lot of "what-ifs":
+
+        i.e. In the scenario User A who is following a private ticket CC's User B who is
+        not, Odoo needs to accept the email, but we cannot just hard block the email as
+        it should be posted. But we also can't just blackhole it.
+
+        This then needs to handle BCC, etc.
+
+        What I've chosen to do is accept the email, post it, but ensure that only the
+        existing users are subscribed.
+
+        This has the side effect of allowing parties without access the ability to
+        potentially post message, but not be auto-subscribed.
+        """
+        if partner_ids and self._context.get(
+            "helpdesk_privacy_only_subscribe_existing_partners"
+        ):
+            partner_ids = [i for i in partner_ids if i in self.message_partner_ids.ids]
+
+        return super()._message_subscribe(
+            partner_ids=partner_ids, subtype_ids=subtype_ids, customer_ids=customer_ids
+        )

--- a/helpdesk_privacy/tests/__init__.py
+++ b/helpdesk_privacy/tests/__init__.py
@@ -1,1 +1,3 @@
+from . import common
 from . import test_helpdesk_team_privacy_visibility
+from . import test_message_subscribe

--- a/helpdesk_privacy/tests/common.py
+++ b/helpdesk_privacy/tests/common.py
@@ -1,0 +1,31 @@
+from odoo.addons.helpdesk.tests.test_helpdesk_team_privacy_visibility import (
+    TestHelpdeskTeamPrivacyVisibility,
+)
+from odoo.addons.mail.tests.common import mail_new_test_user
+
+
+class TestHelpdeskPrivacyCommon(TestHelpdeskTeamPrivacyVisibility):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.portal_user_a = mail_new_test_user(
+            cls.env,
+            name="helpdesk_portal_a",
+            login="helpdesk_portal_a",
+            email="helpdesk_a@portal.com",
+            notification_type="email",
+            groups="base.group_portal",
+        )
+
+        cls.portal_user_b = mail_new_test_user(
+            cls.env,
+            name="helpdesk_portal_b",
+            login="helpdesk_portal_b",
+            email="helpdesk_b@portal.com",
+            notification_type="email",
+            groups="base.group_portal",
+        )
+
+        cls.portal_user_a.partner_id.commercial_partner_id = cls.partner.id
+        cls.portal_user_b.partner_id.commercial_partner_id = cls.partner.id

--- a/helpdesk_privacy/tests/test_helpdesk_team_privacy_visibility.py
+++ b/helpdesk_privacy/tests/test_helpdesk_team_privacy_visibility.py
@@ -1,35 +1,7 @@
-from odoo.addons.helpdesk.tests.test_helpdesk_team_privacy_visibility import (
-    TestHelpdeskTeamPrivacyVisibility,
-)
-from odoo.addons.mail.tests.common import mail_new_test_user
+from .common import TestHelpdeskPrivacyCommon
 
 
-class TestHelpdeskTeamPrivacyVisibility(TestHelpdeskTeamPrivacyVisibility):
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-
-        cls.portal_user_a = mail_new_test_user(
-            cls.env,
-            name="helpdesk_portal_a",
-            login="helpdesk_portal_a",
-            email="helpdesk_a@portal.com",
-            notification_type="email",
-            groups="base.group_portal",
-        )
-
-        cls.portal_user_b = mail_new_test_user(
-            cls.env,
-            name="helpdesk_portal_b",
-            login="helpdesk_portal_b",
-            email="helpdesk_b@portal.com",
-            notification_type="email",
-            groups="base.group_portal",
-        )
-
-        cls.portal_user_a.partner_id.commercial_partner_id = cls.partner.id
-        cls.portal_user_b.partner_id.commercial_partner_id = cls.partner.id
-
+class TestHelpdeskTeamPrivacyVisibility(TestHelpdeskPrivacyCommon):
     def test_helpdesk_team_visibility_private(self):
         self.ticket.write({"partner_id": self.partner.id})
 

--- a/helpdesk_privacy/tests/test_message_subscribe.py
+++ b/helpdesk_privacy/tests/test_message_subscribe.py
@@ -1,0 +1,43 @@
+from .common import TestHelpdeskPrivacyCommon
+
+
+class TestMessageSubscribe(TestHelpdeskPrivacyCommon):
+    def test_private_ticket_message_subscribe(self):
+        ticket_id = self.env["helpdesk.ticket"].create(
+            {
+                "partner_id": self.portal_user_a.partner_id.id,
+                "name": "Test portal user a's private ticket",
+                "is_private": True,
+            }
+        )
+
+        self.assertTrue(self.portal_user_a.partner_id in ticket_id.message_partner_ids)
+        self.assertTrue(
+            self.portal_user_b.partner_id not in ticket_id.message_partner_ids
+        )
+
+        ticket_id.with_context(
+            helpdesk_privacy_only_subscribe_existing_partners=True
+        )._message_subscribe(partner_ids=self.portal_user_b.partner_id.ids)
+
+        self.assertTrue(
+            self.portal_user_b.partner_id not in ticket_id.message_partner_ids
+        )
+
+    def test_public_ticket_message_subscribe(self):
+        ticket_id = self.env["helpdesk.ticket"].create(
+            {
+                "partner_id": self.portal_user_a.partner_id.id,
+                "name": "Test portal user a's public ticket",
+                "is_private": False,
+            }
+        )
+
+        self.assertTrue(self.portal_user_a.partner_id in ticket_id.message_partner_ids)
+        self.assertTrue(
+            self.portal_user_b.partner_id not in ticket_id.message_partner_ids
+        )
+
+        ticket_id._message_subscribe(partner_ids=self.portal_user_b.partner_id.ids)
+
+        self.assertTrue(self.portal_user_b.partner_id in ticket_id.message_partner_ids)


### PR DESCRIPTION
This is not a perfect implementation, but I'm unclear how to better handle better without a lot of "what-ifs":

i.e. In the scenario User A who is following a private ticket CC's User B who is not, Odoo needs to accept the email, but we cannot just hard block the email as it should be posted. 

This then needs to handle BCC, etc.

What I've chosen to do is accept the email, post it, but ensure that only the existing users are subscribed.

This has the side effect of allowing parties without access the ability to potentially post message, but not be auto-subscribed.

I am choosing not to backport this fix as it's a behavioural change.

Fixes GH181524

**Dependencies:**
- N/A

**ARL (Associated Risk Level):**
- [ ] Low
- [x] Medium
- [ ] High

**Type of change:**
- [ ] Forwardport / Backport
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

