### PR TITLE
[17.0][IMP] mail_bounce_catchall_custom_message

### DIFF
--- a/mail_bounce_catchall_custom_message/README.md
+++ b/mail_bounce_catchall_custom_message/README.md
@@ -1,0 +1,3 @@
+# =================================== mail_bounce_catchall_custom_message
+
+Customise the catchall bounce message via the Company.

--- a/mail_bounce_catchall_custom_message/__init__.py
+++ b/mail_bounce_catchall_custom_message/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/mail_bounce_catchall_custom_message/__manifest__.py
+++ b/mail_bounce_catchall_custom_message/__manifest__.py
@@ -1,0 +1,14 @@
+{
+    "name": "mail_bounce_catchall_custom_message",
+    "summary": "Customise the catchall bounce message",
+    "author": "Glo Networks",
+    "website": "https://github.com/GlodoUK/odoo-addons",
+    "category": "Uncategorized",
+    "version": "17.0.1.0.0",
+    "depends": ["mail"],
+    "data": [
+        "views/res_company.xml",
+        "views/templates.xml",
+    ],
+    "license": "LGPL-3",
+}

--- a/mail_bounce_catchall_custom_message/models/__init__.py
+++ b/mail_bounce_catchall_custom_message/models/__init__.py
@@ -1,0 +1,1 @@
+from . import res_company

--- a/mail_bounce_catchall_custom_message/models/res_company.py
+++ b/mail_bounce_catchall_custom_message/models/res_company.py
@@ -1,0 +1,8 @@
+from odoo import fields, models
+
+
+class ResCompany(models.Model):
+    _inherit = "res.company"
+
+    use_custom_catchall_bounce_message = fields.Boolean(default=False)
+    custom_catchall_bounce_message = fields.Html()

--- a/mail_bounce_catchall_custom_message/pyproject.toml
+++ b/mail_bounce_catchall_custom_message/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["whool"]
+build-backend = "whool.buildapi"

--- a/mail_bounce_catchall_custom_message/tests/__init__.py
+++ b/mail_bounce_catchall_custom_message/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_custom_message

--- a/mail_bounce_catchall_custom_message/tests/test_custom_message.py
+++ b/mail_bounce_catchall_custom_message/tests/test_custom_message.py
@@ -1,0 +1,60 @@
+from email.message import EmailMessage
+
+from odoo.tests import TransactionCase
+
+DEFAULT_MARKER = "is used to collect replies and should not be used to directly contact"
+
+
+class TestCustomMessage(TransactionCase):
+    def setUp(self):
+        super().setUp()
+
+        self.company_id = self.env["res.company"].create(
+            {
+                "name": "Test Company A",
+            }
+        )
+
+    def _render_mail_bounce_catchall(self):
+        msg = EmailMessage()
+
+        # Set headers
+        msg["From"] = "alice@example.com"
+        msg["To"] = "bob@example.net"
+        msg["Subject"] = "Test Message"
+        msg["Date"] = "Fri, 13 Jun 2025 10:00:00 -0000"
+        msg["Message-ID"] = "<fake-message-id@example.com>"
+
+        body = (
+            self.env["ir.qweb"]
+            .with_company(self.company_id)
+            ._render(
+                "mail.mail_bounce_catchall",
+                {
+                    "message": msg,
+                },
+            )
+        )
+
+        return body
+
+    def test_no_custom_message(self):
+        self.assertFalse(self.company_id.use_custom_catchall_bounce_message)
+        body = self._render_mail_bounce_catchall()
+        self.assertTrue(DEFAULT_MARKER in body)
+
+    def test_custom_message_plaintext(self):
+        self.company_id.use_custom_catchall_bounce_message = True
+        self.assertTrue(self.company_id.use_custom_catchall_bounce_message)
+        self.company_id.custom_catchall_bounce_message = "TEST123456"
+        body = self._render_mail_bounce_catchall()
+        self.assertTrue(DEFAULT_MARKER not in body)
+        self.assertTrue("TEST123456" in body)
+
+    def test_custom_message_html(self):
+        self.company_id.use_custom_catchall_bounce_message = True
+        self.assertTrue(self.company_id.use_custom_catchall_bounce_message)
+        self.company_id.custom_catchall_bounce_message = "<ul><li>ONE</li></ul>"
+        body = self._render_mail_bounce_catchall()
+        self.assertTrue(DEFAULT_MARKER not in body)
+        self.assertTrue(self.company_id.custom_catchall_bounce_message in body)

--- a/mail_bounce_catchall_custom_message/views/res_company.xml
+++ b/mail_bounce_catchall_custom_message/views/res_company.xml
@@ -1,0 +1,20 @@
+<odoo>
+    <record id="view_company_form" model="ir.ui.view">
+        <field name="name">view_company_form</field>
+        <field name="model">res.company</field>
+        <field name="inherit_id" ref="base.view_company_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//notebook" position="inside">
+                <page
+                    string="Custom Bounce Email"
+                    name="mail_bounce_catchall_custom_message"
+                >
+                    <group>
+                        <field name="use_custom_catchall_bounce_message" />
+                        <field name="custom_catchall_bounce_message" />
+                    </group>
+                </page>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/mail_bounce_catchall_custom_message/views/templates.xml
+++ b/mail_bounce_catchall_custom_message/views/templates.xml
@@ -1,0 +1,18 @@
+<odoo>
+    <template
+        id="mail_bounce_catchall"
+        inherit_id="mail.mail_bounce_catchall"
+        priority="99"
+    >
+        <xpath expr="//div" position="attributes">
+            <attribute
+                name="t-if"
+            >not res_company.use_custom_catchall_bounce_message</attribute>
+        </xpath>
+        <xpath expr="//div" position="after">
+            <div>
+                <t t-esc="res_company.custom_catchall_bounce_message" />
+            </div>
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
Implements a mechanism to override the mail bounce message, per company more easily.

Fixes GH182130

**Dependencies:**
- N/A

**ARL (Associated Risk Level):**
- [x] Low
- [ ] Medium
- [ ] High

**Type of change:**
- [ ] Forwardport / Backport
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

