### PR TITLE
[FIX] product_variant_specific_tax_sale: fix product_variant_easy_edit_view inherited view

### DIFF
--- a/product_variant_specific_tax_sale/views/product_product_views.xml
+++ b/product_variant_specific_tax_sale/views/product_product_views.xml
@@ -5,7 +5,7 @@
         <field name="model">product.product</field>
         <field name="inherit_id" ref="product.product_variant_easy_edit_view" />
         <field name="arch" type="xml">
-            <field name="lst_price" position="after">
+            <field name="additional_product_tag_ids" position="after">
                 <field
                     name="taxes_id"
                     readonly="variant_taxes_id"


### PR DESCRIPTION
Fields were moved into the Sales group for UX reasons

![image](https://github.com/user-attachments/assets/541181e5-eb2b-43e3-beb2-0900ffb27497)

**Dependencies:**
- N/A

**ARL (Associated Risk Level):**
- [X] Low
- [ ] Medium
- [ ] High

**Type of change:**
- [ ] Forwardport / Backport
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

