### PR TITLE
Fix dead get_product_price method

### DIFF
--- a/delivery_parcelhub_whistl/models/delivery_carrier.py
+++ b/delivery_parcelhub_whistl/models/delivery_carrier.py
@@ -214,8 +214,9 @@ class DeliveryCarrier(models.Model):
                 "warning_message": False,
             }
 
-        price = order.pricelist_id.get_product_price(
-            self.product_id, 1.0, order.partner_id
+        price = order.pricelist_id._get_product_price(
+            self.product_id,
+            1.0,
         )
 
         return {

--- a/delivery_spring/models/delivery_carrier.py
+++ b/delivery_spring/models/delivery_carrier.py
@@ -125,8 +125,9 @@ class DeliveryCarrier(models.Model):
                 "warning_message": False,
             }
 
-        price = order.pricelist_id.get_product_price(
-            self.product_id, 1.0, order.partner_id
+        price = order.pricelist_id._get_product_price(
+            self.product_id,
+            1.0,
         )
 
         return {


### PR DESCRIPTION
See

https://github.com/odoo/odoo/blob/15.0/addons/delivery/models/delivery_carrier.py#L283
https://github.com/odoo/odoo/blob/18.0/addons/delivery/models/delivery_carrier.py#L345

**ARL (Associated Risk Level):**
- [X] Low
- [ ] Medium
- [ ] High

**Type of change:**
- [ ] Forwardport / Backport
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

