### PR TITLE
Operation Overkill: Module to propagate notes through generated maintenance requests

### DIFF
--- a/maintenance_request_template/README.rst
+++ b/maintenance_request_template/README.rst
@@ -1,2 +1,16 @@
 maintenance_request_template
 ----------------------------
+
+Preventative maintenance requests can be recurring.
+
+In 18.0 the ``description`` field is copied from the original maintenance request.
+
+If you want to use the ``description`` field as a checklist, for example, then you don't want the checklist values to be propagated to new maintenance requests. This is an overkill module that provides a general framework to achieve this.
+
+Priority 
+
+``equipment_id.template_id.description``
+``equipment_id.category_id.template_id.description``
+``equipment_id.note``
+
+``equipment_id.note`` is used for legacy data reasons

--- a/maintenance_request_template/README.rst
+++ b/maintenance_request_template/README.rst
@@ -1,0 +1,2 @@
+maintenance_requestion_template
+-------------------------------

--- a/maintenance_request_template/README.rst
+++ b/maintenance_request_template/README.rst
@@ -1,2 +1,2 @@
-maintenance_requestion_template
--------------------------------
+maintenance_request_template
+----------------------------

--- a/maintenance_request_template/__init__.py
+++ b/maintenance_request_template/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/maintenance_request_template/__manifest__.py
+++ b/maintenance_request_template/__manifest__.py
@@ -1,0 +1,14 @@
+{
+    "name": "maintenance_request_template",
+    "version": "18.0.1.0.0",
+    "author": "Glo Networks",
+    "website": "https://github.com/GlodoUK/odoo-addons",
+    "depends": ["maintenance"],
+    "data": [
+        "security/ir.model.access.csv",
+        "views/maintenance_equipment_category_views.xml",
+        "views/maintenance_equipment_template_views.xml",
+        "views/maintenance_equipment_views.xml",
+    ],
+    "license": "LGPL-3",
+}

--- a/maintenance_request_template/models/__init__.py
+++ b/maintenance_request_template/models/__init__.py
@@ -1,0 +1,4 @@
+from . import maintenance_equipment
+from . import maintenance_equipment_category
+from . import maintenance_equipment_template
+from . import maintenance_request

--- a/maintenance_request_template/models/maintenance_equipment.py
+++ b/maintenance_request_template/models/maintenance_equipment.py
@@ -1,0 +1,15 @@
+from odoo import fields, models
+
+
+class MaintenanceEquipment(models.Model):
+    _inherit = "maintenance.equipment"
+
+    template_id = fields.Many2one(
+        "maintenance.equipment.template",
+    )
+
+    def _get_template_id(self):
+        if not self:
+            return self
+        self.ensure_one()
+        return self.template_id or self.category_id.template_id

--- a/maintenance_request_template/models/maintenance_equipment.py
+++ b/maintenance_request_template/models/maintenance_equipment.py
@@ -8,8 +8,10 @@ class MaintenanceEquipment(models.Model):
         "maintenance.equipment.template",
     )
 
+    def _get_description(self):
+        self.ensure_one()
+        return self._get_template_id().description or self.note
+
     def _get_template_id(self):
-        if not self:
-            return self
         self.ensure_one()
         return self.template_id or self.category_id.template_id

--- a/maintenance_request_template/models/maintenance_equipment_category.py
+++ b/maintenance_request_template/models/maintenance_equipment_category.py
@@ -1,0 +1,9 @@
+from odoo import fields, models
+
+
+class MaintenanceEquipmentCategory(models.Model):
+    _inherit = "maintenance.equipment.category"
+
+    template_id = fields.Many2one(
+        "maintenance.equipment.template",
+    )

--- a/maintenance_request_template/models/maintenance_equipment_template.py
+++ b/maintenance_request_template/models/maintenance_equipment_template.py
@@ -1,0 +1,60 @@
+from odoo import fields, models
+
+
+class MaintenanceEquipmentTemplate(models.Model):
+    _name = "maintenance.equipment.template"
+    _description = "Maintenance Equipment Template"
+
+    active = fields.Boolean(
+        default=True,
+    )
+
+    name = fields.Char(
+        required=True,
+    )
+
+    sequence = fields.Integer(
+        default=10,
+    )
+
+    description = fields.Html(
+        required=True,
+    )
+
+    categ_count = fields.Integer(
+        compute="_compute_categ_count",
+        string="Categories",
+    )
+
+    equipment_count = fields.Integer(
+        compute="_compute_equipment_count",
+        string="Equipment",
+    )
+
+    def _compute_categ_count(self):
+        data = self.env["maintenance.equipment.category"].read_group(
+            [("template_id", "in", self.ids)],
+            ["template_id"],
+            ["template_id"],
+        )
+
+        mapped_data = dict(
+            [(m["template_id"][0], m["template_id_count"]) for m in data]
+        )
+
+        for template in self:
+            template.categ_count = mapped_data.get(template.id, 0)
+
+    def _compute_equipment_count(self):
+        data = self.env["maintenance.equipment"].read_group(
+            [("template_id", "in", self.ids)],
+            ["template_id"],
+            ["template_id"],
+        )
+
+        mapped_data = dict(
+            [(m["template_id"][0], m["template_id_count"]) for m in data]
+        )
+
+        for template in self:
+            template.equipment_count = mapped_data.get(template.id, 0)

--- a/maintenance_request_template/models/maintenance_request.py
+++ b/maintenance_request_template/models/maintenance_request.py
@@ -7,7 +7,7 @@ class MaintenanceRequest(models.Model):
     def copy_data(self, default=None):
         default = dict(default or {})
         vals_list = super().copy_data(default=default)
-        for request, vals in zip(self, vals_list):
+        for request, vals in zip(self, vals_list, strict=False):
             if request.equipment_id._get_description():
                 vals["description"] = request.equipment_id._get_description()
         return vals_list

--- a/maintenance_request_template/models/maintenance_request.py
+++ b/maintenance_request_template/models/maintenance_request.py
@@ -4,13 +4,13 @@ from odoo import api, models
 class MaintenanceRequest(models.Model):
     _inherit = "maintenance.request"
 
-    @api.model_create_multi
-    def create(self, vals_list):
-        maintenance_requests = super().create(vals_list)
-        for request in maintenance_requests:
+    def copy_data(self, default=None):
+        default = dict(default or {})
+        vals_list = super().copy_data(default=default)
+        for request, vals in zip(self, vals_list):
             if request.equipment_id:
-                request.description = request.equipment_id._get_description()
-        return maintenance_requests
+                vals["description"] = request.equipment_id._get_description()
+        return vals_list
 
     @api.onchange("equipment_id")
     def _onchange_equipment_id_template_id(self):

--- a/maintenance_request_template/models/maintenance_request.py
+++ b/maintenance_request_template/models/maintenance_request.py
@@ -7,23 +7,13 @@ class MaintenanceRequest(models.Model):
     @api.model_create_multi
     def create(self, vals_list):
         maintenance_requests = super().create(vals_list)
-
         for request in maintenance_requests:
-            description = (
-                self.equipment_id.note
-                or self.equipment_id._get_template_id().description
-            )
-            if description:
-                request.description = description
-
+            if request.equipment_id:
+                request.description = request.equipment_id._get_description()
         return maintenance_requests
 
     @api.onchange("equipment_id")
     def _onchange_equipment_id_template_id(self):
         self.ensure_one()
-        description = (
-            self.equipment_id.note
-            or self.equipment_id._get_template_id().description
-        )
-        if description:
-            self.description = description
+        if self.equipment_id:
+            self.description = self.equipment_id._get_description()

--- a/maintenance_request_template/models/maintenance_request.py
+++ b/maintenance_request_template/models/maintenance_request.py
@@ -22,7 +22,8 @@ class MaintenanceRequest(models.Model):
     def _onchange_equipment_id_template_id(self):
         self.ensure_one()
         description = (
-            self.equipment_id.note or self.equipment_id._get_template_id().description
+            self.equipment_id.note
+            or self.equipment_id._get_template_id().description
         )
         if description:
             self.description = description

--- a/maintenance_request_template/models/maintenance_request.py
+++ b/maintenance_request_template/models/maintenance_request.py
@@ -8,7 +8,7 @@ class MaintenanceRequest(models.Model):
         default = dict(default or {})
         vals_list = super().copy_data(default=default)
         for request, vals in zip(self, vals_list):
-            if request.equipment_id:
+            if request.equipment_id._get_description():
                 vals["description"] = request.equipment_id._get_description()
         return vals_list
 

--- a/maintenance_request_template/models/maintenance_request.py
+++ b/maintenance_request_template/models/maintenance_request.py
@@ -1,0 +1,28 @@
+from odoo import api, models
+
+
+class MaintenanceRequest(models.Model):
+    _inherit = "maintenance.request"
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        maintenance_requests = super().create(vals_list)
+
+        for request in maintenance_requests:
+            description = (
+                self.equipment_id.note
+                or self.equipment_id._get_template_id().description
+            )
+            if description:
+                request.description = description
+
+        return maintenance_requests
+
+    @api.onchange("equipment_id")
+    def _onchange_equipment_id_template_id(self):
+        self.ensure_one()
+        description = (
+            self.equipment_id.note or self.equipment_id._get_template_id().description
+        )
+        if description:
+            self.description = description

--- a/maintenance_request_template/pyproject.toml
+++ b/maintenance_request_template/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["whool"]
+build-backend = "whool.buildapi"

--- a/maintenance_request_template/security/ir.model.access.csv
+++ b/maintenance_request_template/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_maintenance_equipment_template,access.maintenance.equipment.template,model_maintenance_equipment_template,base.group_user,1,1,1,1

--- a/maintenance_request_template/tests/__init__.py
+++ b/maintenance_request_template/tests/__init__.py
@@ -1,0 +1,2 @@
+from . import common
+from . import test_maintenance_request_template

--- a/maintenance_request_template/tests/common.py
+++ b/maintenance_request_template/tests/common.py
@@ -2,7 +2,6 @@ from odoo.tests import TransactionCase
 
 
 class MaintenanceRequestTemplateCommon(TransactionCase):
-
     @classmethod
     def setUpClass(cls):
         super().setUpClass()

--- a/maintenance_request_template/tests/common.py
+++ b/maintenance_request_template/tests/common.py
@@ -12,28 +12,38 @@ class MaintenanceRequestTemplateCommon(TransactionCase):
         cls.EquipmentTemplate = cls.env["maintenance.equipment.template"]
         cls.Request = cls.env["maintenance.request"]
 
-        cls.templateA = cls.EquipmentTemplate.create({
-            "name": "Template A",
-            "description": "Equipment Description",
-        })
+        cls.templateA = cls.EquipmentTemplate.create(
+            {
+                "name": "Template A",
+                "description": "Equipment Description",
+            }
+        )
 
-        cls.templateB = cls.EquipmentTemplate.create({
-            "name": "Template B",
-            "description": "Categ Description",
-        })
+        cls.templateB = cls.EquipmentTemplate.create(
+            {
+                "name": "Template B",
+                "description": "Categ Description",
+            }
+        )
 
-        cls.categA = cls.EquipmentCateg.create({
-            "name": "CategA",
-            "template_id": cls.templateB.id,
-        })
+        cls.categA = cls.EquipmentCateg.create(
+            {
+                "name": "CategA",
+                "template_id": cls.templateB.id,
+            }
+        )
 
-        cls.equipmentA = cls.Equipment.create({
-            "name": "EquipmentA",
-            "category_id": cls.categA.id,
-            "template_id": cls.templateA.id,
-        })
+        cls.equipmentA = cls.Equipment.create(
+            {
+                "name": "EquipmentA",
+                "category_id": cls.categA.id,
+                "template_id": cls.templateA.id,
+            }
+        )
 
-        cls.equipmentB = cls.Equipment.create({
-            "name": "EquipmentB",
-            "category_id": cls.categA.id,
-        })
+        cls.equipmentB = cls.Equipment.create(
+            {
+                "name": "EquipmentB",
+                "category_id": cls.categA.id,
+            }
+        )

--- a/maintenance_request_template/tests/common.py
+++ b/maintenance_request_template/tests/common.py
@@ -1,0 +1,39 @@
+from odoo.tests import TransactionCase
+
+
+class MaintenanceRequestTemplateCommon(TransactionCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.Equipment = cls.env["maintenance.equipment"]
+        cls.EquipmentCateg = cls.env["maintenance.equipment.category"]
+        cls.EquipmentTemplate = cls.env["maintenance.equipment.template"]
+        cls.Request = cls.env["maintenance.request"]
+
+        cls.templateA = cls.EquipmentTemplate.create({
+            "name": "Template A",
+            "description": "Equipment Description",
+        })
+
+        cls.templateB = cls.EquipmentTemplate.create({
+            "name": "Template B",
+            "description": "Categ Description",
+        })
+
+        cls.categA = cls.EquipmentCateg.create({
+            "name": "CategA",
+            "template_id": cls.templateB.id,
+        })
+
+        cls.equipmentA = cls.Equipment.create({
+            "name": "EquipmentA",
+            "category_id": cls.categA.id,
+            "template_id": cls.templateA.id,
+        })
+
+        cls.equipmentB = cls.Equipment.create({
+            "name": "EquipmentB",
+            "category_id": cls.categA.id,
+        })

--- a/maintenance_request_template/tests/test_maintenance_request_template.py
+++ b/maintenance_request_template/tests/test_maintenance_request_template.py
@@ -5,10 +5,12 @@ from .common import MaintenanceRequestTemplateCommon
 
 class TestMaintenanceRequestTemplate(MaintenanceRequestTemplateCommon):
     def test_template_onchange(self):
-        request_id = self.Request.create({
-            "name": "Request",
-            "stage_id": self.env.ref("maintenance.stage_0").id,
-        })
+        request_id = self.Request.create(
+            {
+                "name": "Request",
+                "stage_id": self.env.ref("maintenance.stage_0").id,
+            }
+        )
 
         with Form(request_id) as request_form:
             request_form.equipment_id = self.equipmentA
@@ -28,11 +30,13 @@ class TestMaintenanceRequestTemplate(MaintenanceRequestTemplateCommon):
             )
 
     def test_template_category(self):
-        request_id = self.Request.create({
-            "name": "Request",
-            "equipment_id": self.equipmentB.id,
-            "stage_id": self.env.ref("maintenance.stage_0").id,
-        })
+        request_id = self.Request.create(
+            {
+                "name": "Request",
+                "equipment_id": self.equipmentB.id,
+                "stage_id": self.env.ref("maintenance.stage_0").id,
+            }
+        )
 
         self.assertEqual(
             request_id.description,
@@ -40,11 +44,13 @@ class TestMaintenanceRequestTemplate(MaintenanceRequestTemplateCommon):
         )
 
     def test_template_equipment(self):
-        request_id = self.Request.create({
-            "name": "Request",
-            "equipment_id": self.equipmentA.id,
-            "stage_id": self.env.ref("maintenance.stage_0").id,
-        })
+        request_id = self.Request.create(
+            {
+                "name": "Request",
+                "equipment_id": self.equipmentA.id,
+                "stage_id": self.env.ref("maintenance.stage_0").id,
+            }
+        )
 
         self.assertEqual(
             request_id.description,
@@ -56,11 +62,13 @@ class TestMaintenanceRequestTemplate(MaintenanceRequestTemplateCommon):
         self.equipmentA.category_id.template_id.description = False
         self.equipmentA.note = "equipmentA Note"
 
-        request_id = self.Request.create({
-            "name": "Request",
-            "equipment_id": self.equipmentA.id,
-            "stage_id": self.env.ref("maintenance.stage_0").id,
-        })
+        request_id = self.Request.create(
+            {
+                "name": "Request",
+                "equipment_id": self.equipmentA.id,
+                "stage_id": self.env.ref("maintenance.stage_0").id,
+            }
+        )
 
         self.assertEqual(
             request_id.description,

--- a/maintenance_request_template/tests/test_maintenance_request_template.py
+++ b/maintenance_request_template/tests/test_maintenance_request_template.py
@@ -41,7 +41,7 @@ class TestMaintenanceRequestTemplate(MaintenanceRequestTemplateCommon):
 
         self.assertEqual(
             request_id.description,
-            self.equipmentA.category_id.template_id.description,
+            self.equipmentB.category_id.template_id.description,
         )
 
     def test_template_equipment(self):

--- a/maintenance_request_template/tests/test_maintenance_request_template.py
+++ b/maintenance_request_template/tests/test_maintenance_request_template.py
@@ -30,6 +30,12 @@ class TestMaintenanceRequestTemplate(MaintenanceRequestTemplateCommon):
             )
 
     def test_template_category(self):
+        """
+        equipment_id.category_id.description is not set
+        equipment_id.category_id.template_id.description is set
+
+        equipment_id.category_id.template_id.description is used
+        """
         request_id = self.Request.create(
             {
                 "name": "Request",
@@ -45,6 +51,12 @@ class TestMaintenanceRequestTemplate(MaintenanceRequestTemplateCommon):
         )
 
     def test_template_equipment(self):
+        """
+        equipment_id.category_id.description is set
+        equipment_id.category_id.template_id.description is set
+
+        equipment_id.category_id.template_id is used
+        """
         request_id = self.Request.create(
             {
                 "name": "Request",
@@ -59,7 +71,13 @@ class TestMaintenanceRequestTemplate(MaintenanceRequestTemplateCommon):
             self.equipmentA.template_id.description,
         )
 
-    def test_template_none(self):
+    def test_note(self):
+        """
+        category_id.description is not set
+        category_id.template_id.description is not set
+
+        equipment_id.note is used as a fallback
+        """
         self.equipmentA.template_id.description = False
         self.equipmentA.category_id.template_id.description = False
         self.equipmentA.note = "equipmentA Note"

--- a/maintenance_request_template/tests/test_maintenance_request_template.py
+++ b/maintenance_request_template/tests/test_maintenance_request_template.py
@@ -35,8 +35,9 @@ class TestMaintenanceRequestTemplate(MaintenanceRequestTemplateCommon):
                 "name": "Request",
                 "equipment_id": self.equipmentB.id,
                 "stage_id": self.env.ref("maintenance.stage_0").id,
+                "description": "ABC",
             }
-        )
+        ).copy()
 
         self.assertEqual(
             request_id.description,
@@ -49,8 +50,9 @@ class TestMaintenanceRequestTemplate(MaintenanceRequestTemplateCommon):
                 "name": "Request",
                 "equipment_id": self.equipmentA.id,
                 "stage_id": self.env.ref("maintenance.stage_0").id,
+                "description": "ABC",
             }
-        )
+        ).copy()
 
         self.assertEqual(
             request_id.description,
@@ -67,8 +69,9 @@ class TestMaintenanceRequestTemplate(MaintenanceRequestTemplateCommon):
                 "name": "Request",
                 "equipment_id": self.equipmentA.id,
                 "stage_id": self.env.ref("maintenance.stage_0").id,
+                "description": "ABC",
             }
-        )
+        ).copy()
 
         self.assertEqual(
             request_id.description,

--- a/maintenance_request_template/tests/test_maintenance_request_template.py
+++ b/maintenance_request_template/tests/test_maintenance_request_template.py
@@ -1,0 +1,68 @@
+from odoo.tests import Form
+
+from .common import MaintenanceRequestTemplateCommon
+
+
+class TestMaintenanceRequestTemplate(MaintenanceRequestTemplateCommon):
+    def test_template_onchange(self):
+        request_id = self.Request.create({
+            "name": "Request",
+            "stage_id": self.env.ref("maintenance.stage_0").id,
+        })
+
+        with Form(request_id) as request_form:
+            request_form.equipment_id = self.equipmentA
+            request_form.save()
+
+            self.assertEqual(
+                request_form.description,
+                self.equipmentA.template_id.description,
+            )
+
+            request_form.equipment_id = self.equipmentB
+            request_form.save()
+
+            self.assertEqual(
+                request_form.description,
+                self.equipmentB.category_id.template_id.description,
+            )
+
+    def test_template_category(self):
+        request_id = self.Request.create({
+            "name": "Request",
+            "equipment_id": self.equipmentB.id,
+            "stage_id": self.env.ref("maintenance.stage_0").id,
+        })
+
+        self.assertEqual(
+            request_id.description,
+            self.equipmentA.category_id.template_id.description,
+        )
+
+    def test_template_equipment(self):
+        request_id = self.Request.create({
+            "name": "Request",
+            "equipment_id": self.equipmentA.id,
+            "stage_id": self.env.ref("maintenance.stage_0").id,
+        })
+
+        self.assertEqual(
+            request_id.description,
+            self.equipmentA.template_id.description,
+        )
+
+    def test_template_none(self):
+        self.equipmentA.template_id.description = False
+        self.equipmentA.category_id.template_id.description = False
+        self.equipmentA.note = "equipmentA Note"
+
+        request_id = self.Request.create({
+            "name": "Request",
+            "equipment_id": self.equipmentA.id,
+            "stage_id": self.env.ref("maintenance.stage_0").id,
+        })
+
+        self.assertEqual(
+            request_id.description,
+            self.equipmentA.note,
+        )

--- a/maintenance_request_template/views/maintenance_equipment_category_views.xml
+++ b/maintenance_request_template/views/maintenance_equipment_category_views.xml
@@ -1,0 +1,29 @@
+<?xml version='1.0' encoding='utf-8' ?>
+<odoo>
+    <record id="hr_equipment_category_view_form" model="ir.ui.view">
+        <field name="name">equipment.category.form</field>
+        <field name="model">maintenance.equipment.category</field>
+        <field name="inherit_id" ref="maintenance.hr_equipment_category_view_form" />
+        <field name="arch" type="xml">
+            <field name="technician_user_id" position="after">
+                <field name="template_id" />
+            </field>
+        </field>
+    </record>
+
+    <record id="hr_equipment_category_view_search" model="ir.ui.view">
+        <field name="name">equipment.category.search</field>
+        <field name="model">maintenance.equipment.category</field>
+        <field name="inherit_id" ref="maintenance.hr_equipment_category_view_search" />
+        <field name="arch" type="xml">
+            <filter name="responsible" position="after">
+                <filter
+                    string="Template"
+                    name="template_id"
+                    domain="[]"
+                    context="{'group_by' : 'template_id'}"
+                />
+            </filter>
+        </field>
+    </record>
+</odoo>

--- a/maintenance_request_template/views/maintenance_equipment_template_views.xml
+++ b/maintenance_request_template/views/maintenance_equipment_template_views.xml
@@ -1,0 +1,128 @@
+<?xml version='1.0' encoding='utf-8' ?>
+<odoo>
+    <record id="hr_equipment_action_from_template_form" model="ir.actions.act_window">
+        <field name="name">Equipment</field>
+        <field name="res_model">maintenance.equipment</field>
+        <field name="view_mode">kanban,list,form</field>
+        <field name="search_view_id" ref="maintenance.hr_equipment_view_search" />
+        <field name="view_id" ref="maintenance.hr_equipment_view_kanban" />
+        <field
+            name="context"
+        >{'search_default_template_id': [active_id], 'default_template_id': active_id}</field>
+    </record>
+
+    <record id="hr_category_action_from_template_form" model="ir.actions.act_window">
+        <field name="name">Categories</field>
+        <field name="res_model">maintenance.equipment.category</field>
+        <field name="view_mode">kanban,list,form</field>
+        <field
+            name="search_view_id"
+            ref="maintenance.hr_equipment_category_view_search"
+        />
+        <field
+            name="view_id"
+            ref="maintenance.view_maintenance_equipment_category_kanban"
+        />
+        <field
+            name="context"
+        >{'search_default_template_id': [active_id], 'default_template_id': active_id}</field>
+    </record>
+
+    <record id="hr_equipment_template_view_form" model="ir.ui.view">
+        <field name="name">equipment.template.form</field>
+        <field name="model">maintenance.equipment.template</field>
+        <field name="arch" type="xml">
+            <form>
+                <sheet>
+                    <div class="oe_button_box" name="button_box">
+                        <button
+                            name="%(hr_equipment_action_from_template_form)d"
+                            type="action"
+                            class="oe_stat_button"
+                            icon="fa-cubes"
+                        >
+                            <field
+                                string="Equipment"
+                                name="equipment_count"
+                                widget="statinfo"
+                            />
+                        </button>
+
+                        <button
+                            name="%(hr_category_action_from_template_form)d"
+                            type="action"
+                            class="oe_stat_button"
+                            icon="fa-gear"
+                        >
+                            <field
+                                string="Categories"
+                                name="categ_count"
+                                widget="statinfo"
+                            />
+                        </button>
+                    </div>
+
+                    <div class="oe_title">
+                        <label for="name" string="Template Name" />
+                        <h1>
+                            <field name="name" placeholder="e.g. Monitors" />
+                        </h1>
+                    </div>
+
+                    <notebook>
+                        <page string="Description" name="description">
+                            <field name="description" />
+                        </page>
+                    </notebook>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="hr_equipment_template_view_tree" model="ir.ui.view">
+        <field name="name">equipment.template.list</field>
+        <field name="model">maintenance.equipment.template</field>
+        <field name="arch" type="xml">
+            <list>
+                <field name="name" />
+            </list>
+        </field>
+    </record>
+
+    <record id="hr_equipment_template_view_search" model="ir.ui.view">
+        <field name="name">equipment.template.search</field>
+        <field name="model">maintenance.equipment.template</field>
+        <field name="arch" type="xml">
+            <search string="Equipment Template Search">
+                <filter
+                    string="Active"
+                    name="active"
+                    domain="[('active', '=', True)]"
+                />
+                <filter
+                    string="Inactive"
+                    name="inactive"
+                    domain="[('active', '=', False)]"
+                />
+            </search>
+        </field>
+    </record>
+
+    <record id="hr_equipment_template_action" model="ir.actions.act_window">
+        <field name="name">Equipment Templates</field>
+        <field name="res_model">maintenance.equipment.template</field>
+        <field name="view_id" ref="hr_equipment_template_view_tree" />
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                Add a new equipment template!
+            </p>
+        </field>
+    </record>
+
+    <menuitem
+        id="maintenance_menu_config_template"
+        action="hr_equipment_template_action"
+        parent="maintenance.menu_maintenance_configuration"
+        sequence="15"
+    />
+</odoo>

--- a/maintenance_request_template/views/maintenance_equipment_template_views.xml
+++ b/maintenance_request_template/views/maintenance_equipment_template_views.xml
@@ -84,6 +84,7 @@
         <field name="model">maintenance.equipment.template</field>
         <field name="arch" type="xml">
             <list>
+                <field name="sequence" widget="handle" />
                 <field name="name" />
             </list>
         </field>

--- a/maintenance_request_template/views/maintenance_equipment_views.xml
+++ b/maintenance_request_template/views/maintenance_equipment_views.xml
@@ -1,0 +1,29 @@
+<?xml version='1.0' encoding='utf-8' ?>
+<odoo>
+    <record id="hr_equipment_view_form" model="ir.ui.view">
+        <field name="name">equipment.form</field>
+        <field name="model">maintenance.equipment</field>
+        <field name="inherit_id" ref="maintenance.hr_equipment_view_form" />
+        <field name="arch" type="xml">
+            <field name="category_id" position="after">
+                <field name="template_id" />
+            </field>
+        </field>
+    </record>
+
+    <record id="hr_equipment_view_search" model="ir.ui.view">
+        <field name="name">equipment.search</field>
+        <field name="model">maintenance.equipment</field>
+        <field name="inherit_id" ref="maintenance.hr_equipment_view_search" />
+        <field name="arch" type="xml">
+            <filter name="category" position="after">
+                <filter
+                    string="Template"
+                    name="template_id"
+                    domain="[]"
+                    context="{'group_by': 'template_id'}"
+                />
+            </filter>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
**Use Case:**

Preventative maintenance requests can be recurring. In 18.0 the `description` field is copied from the original maintenance request. If you want to use the `description` field as a checklist, for example, then you don't want the checklist values to be propagated to new maintenance requests. This is an overkill module that provides a general framework to achieve this.

Priority 

`equipment_id.template_id.description`
`equipment_id.category_id.template_id.description`
`equipment_id.note`

`equipment_id.note` is used for legacy data reasons

**Dependencies:**
- N/A

**ARL (Associated Risk Level):**
- [X] Low
- [ ] Medium
- [ ] High

**Type of change:**
- [ ] Forwardport / Backport
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

