### PR TITLE
T14530 - Allow 'Markup' module in safe_eval for message_post

### DIFF
--- a/connector_edi/components/abstract.py
+++ b/connector_edi/components/abstract.py
@@ -9,6 +9,7 @@ import lxml.builder as builder
 import lxml.etree
 import lxml.objectify
 import requests
+from markupsafe import Markup
 
 from odoo import _, fields, models
 from odoo.exceptions import UserError, ValidationError
@@ -140,6 +141,7 @@ class AbstractEdiComponent(AbstractComponent):
             "ValidationError": ValidationError,
             "OSError": OSError,
             "RetryableJobError": RetryableJobError,
+            "Markup": Markup,
             # Debuggers
             "wdb": wrapped_wdb,
         }

--- a/sale_order_hold_stock_picking_hold/models/sale_order.py
+++ b/sale_order_hold_stock_picking_hold/models/sale_order.py
@@ -4,6 +4,11 @@ from odoo import models
 class SaleOrder(models.Model):
     _inherit = "sale.order"
 
+    def _action_confirm(self):
+        res = super()._action_confirm()
+        self.filtered(lambda order: order.hold).picking_ids.write({"hold": True})
+        return res
+
     def action_hold(self, reason_id=None, msg=None):
         res = super().action_hold(reason_id=reason_id, msg=msg)
 

--- a/sale_order_hold_stock_picking_hold/tests/test_hold.py
+++ b/sale_order_hold_stock_picking_hold/tests/test_hold.py
@@ -62,3 +62,15 @@ class TestStockPickingHold(TransactionCase):
         self.assertFalse(
             sale_id.picking_ids.hold, "The linked picking should not be on hold!"
         )
+
+    def test_hold_before_confirm(self):
+        order = self.env["sale.order"].create({"partner_id": self.partner_id.id})
+        self.env["sale.order.line"].create(
+            {"product_id": self.product_id.id, "order_id": order.id}
+        )
+
+        order.action_hold()
+        order.action_confirm()
+
+        self.assertEqual(len(order.picking_ids), 1)
+        self.assertTrue(False not in order.picking_ids.mapped("hold"))


### PR DESCRIPTION
Fixes T14530

**Dependencies:**
- N/A

**ARL (Associated Risk Level):**
- [ ] Low
- [x] Medium
- [ ] High

**Type of change:**
- [ ] Forwardport / Backport
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

