### PR TITLE
[FEAT] whistl_get_tracking_link method

### DIFF
--- a/delivery_parcelhub_whistl/models/delivery_carrier.py
+++ b/delivery_parcelhub_whistl/models/delivery_carrier.py
@@ -162,6 +162,10 @@ class DeliveryCarrier(models.Model):
         default="6",
     )  # TODO: Flesh this out, or pull from API
 
+    def whistl_get_tracking_link(self, picking):
+        formatted_zip = picking.partner_id.zip.replace(" ", "").upper()
+        return f"https://web.parcelhub.net/Tracking/reference/{picking.carrier_tracking_ref}/postcode/{formatted_zip}"
+
     def _whistl_ensure_valid_shipping(self, pickings):
         MAX_LEN = 32
 

--- a/delivery_parcelhub_whistl/models/delivery_carrier.py
+++ b/delivery_parcelhub_whistl/models/delivery_carrier.py
@@ -577,6 +577,7 @@ class DeliveryCarrier(models.Model):
             picking.write(
                 {
                     "carrier_consignment_ref": picking.name,
+                    "carrier_tracking_ref": tracking,
                     "whistl_carrier": f"{carrier_name}: {service_name}",
                     "delivery_state": "in_transit",
                 }


### PR DESCRIPTION
Propagates to `tracking_url` on stock pickings via Odoo's standard `%s_get_tracking_link` functionality

**Dependencies:**
- N/A

**ARL (Associated Risk Level):**
- [X] Low
- [ ] Medium
- [ ] High

**Type of change:**
- [ ] Forwardport / Backport
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

