### PR TITLE
feat(product_variant_exclusion): Product exclusions don't work as an AND combination. This adds support for this.

### DIFF
--- a/product_variant_exclusion/README.rst
+++ b/product_variant_exclusion/README.rst
@@ -1,0 +1,7 @@
+=========================
+product_variant_exclusion
+=========================
+
+Exact product variant exclusions.
+
+Add an exclusion by a combination of product template attribute values

--- a/product_variant_exclusion/__init__.py
+++ b/product_variant_exclusion/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/product_variant_exclusion/__manifest__.py
+++ b/product_variant_exclusion/__manifest__.py
@@ -1,0 +1,14 @@
+{
+    "name": "product_variant_exclusion",
+    "summary": "Short (1 phrase/line) summary of the module's purpose",
+    "author": "Glo Networks",
+    "website": "https://github.com/GlodoUK/odoo-addons",
+    "category": "Uncategorized",
+    "version": "18.0.1.0.0",
+    "depends": ["product"],
+    "license": "Other proprietary",
+    "data": [
+        "security/ir.model.access.csv",
+        "views/product_template.xml",
+    ],
+}

--- a/product_variant_exclusion/models/__init__.py
+++ b/product_variant_exclusion/models/__init__.py
@@ -1,0 +1,1 @@
+from . import product_variant_exclusion

--- a/product_variant_exclusion/models/product_variant_exclusion.py
+++ b/product_variant_exclusion/models/product_variant_exclusion.py
@@ -1,0 +1,87 @@
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
+
+
+class ProductTemplate(models.Model):
+    _inherit = "product.template"
+
+    product_variant_exclusion_ids = fields.One2many(
+        "product.variant.exclusion", "tmpl_id"
+    )
+
+    def _filter_combinations_impossible_by_config(
+        self, combination_tuples, ignore_no_variant=False
+    ):
+        res = super()._filter_combinations_impossible_by_config(
+            combination_tuples, ignore_no_variant=ignore_no_variant
+        )
+        exclusions = self.product_variant_exclusion_ids
+        yield from [
+            combination
+            for combination in res
+            if not any(
+                all(ptav in combination for ptav in ex.ptav_ids) for ex in exclusions
+            )
+        ]
+
+
+class ProductVariantExclusion(models.Model):
+    _name = "product.variant.exclusion"
+    _description = "Product Variant Exclusion"
+
+    tmpl_id = fields.Many2one("product.template", required=True, index=True)
+    ptav_ids = fields.Many2many(
+        "product.template.attribute.value",
+        "product_variant_exclusion_ptav_rel",
+        domain="[('product_tmpl_id', '=', tmpl_id), ('attribute_id.create_variant', '!=', 'no_variant')]",  # noqa: E501
+        string="Combination to Exclude",
+    )
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        records = super().create(vals_list)
+        for tmpl_id in records.mapped("tmpl_id"):
+            tmpl_id._create_variant_ids()
+        return records
+
+    def write(self, vals):
+        res = super().write(vals)
+        if any(k in ("tmpl_id", "ptav_ids") for k in vals.keys()):
+            for tmpl_id in self.mapped("tmpl_id"):
+                tmpl_id._create_variant_ids()
+        return res
+
+    def unlink(self):
+        tmpl_ids = self.mapped("tmpl_id")
+        res = super().unlink()
+        for tmpl_id in tmpl_ids:
+            tmpl_id._create_variant_ids()
+        return res
+
+    @api.constrains("ptav_ids", "tmpl_id")
+    def _check_ptavs(self):
+        for record in self:
+            seen = self.env["product.attribute"]
+
+            if not record.ptav_ids:
+                raise ValidationError(
+                    _("At least 1 product template attribute value is required!")
+                )
+
+            for ptav_id in record.ptav_ids:
+                if record.tmpl_id != ptav_id.product_tmpl_id:
+                    raise ValidationError(
+                        _(
+                            "Product template attribute value does belong to product"
+                            " template"
+                        )
+                    )
+
+                if ptav_id.attribute_id in seen:
+                    raise ValidationError(
+                        _(
+                            "Duplicate attribute '%(name)s' found",
+                            name=ptav_id.attribute_id.name,
+                        )
+                    )
+                seen |= ptav_id.attribute_id

--- a/product_variant_exclusion/pyproject.toml
+++ b/product_variant_exclusion/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["whool"]
+build-backend = "whool.buildapi"

--- a/product_variant_exclusion/security/ir.model.access.csv
+++ b/product_variant_exclusion/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_product_variant_exclusion,access_product_variant_exclusion,model_product_variant_exclusion,base.group_user,1,1,1,1
+access_product_variant_exclusion_public,access_product_variant_exclusion_public,model_product_variant_exclusion,base.group_public,1,0,0,0

--- a/product_variant_exclusion/tests/__init__.py
+++ b/product_variant_exclusion/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_exclusion

--- a/product_variant_exclusion/tests/test_exclusion.py
+++ b/product_variant_exclusion/tests/test_exclusion.py
@@ -1,0 +1,155 @@
+from odoo import Command
+from odoo.tests import TransactionCase
+
+
+class TestExclusion(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.size_attribute = cls.env["product.attribute"].create(
+            {
+                "name": "Size",
+                "value_ids": [
+                    Command.create({"name": "S"}),
+                    Command.create({"name": "M"}),
+                    Command.create({"name": "L"}),
+                ],
+            }
+        )
+        (
+            cls.size_attribute_s,
+            cls.size_attribute_m,
+            cls.size_attribute_l,
+        ) = cls.size_attribute.value_ids
+
+        cls.colour_attribute = cls.env["product.attribute"].create(
+            {
+                "name": "Colour",
+                "value_ids": [
+                    Command.create({"name": "red", "sequence": 1}),
+                    Command.create({"name": "blue", "sequence": 2}),
+                    Command.create({"name": "green", "sequence": 3}),
+                ],
+            }
+        )
+        (
+            cls.color_attribute_red,
+            cls.color_attribute_blue,
+            cls.color_attribute_green,
+        ) = cls.colour_attribute.value_ids
+
+        cls.thing_attribute = cls.env["product.attribute"].create(
+            {
+                "name": "Thing",
+                "value_ids": [
+                    Command.create({"name": "1", "sequence": 1}),
+                    Command.create({"name": "2", "sequence": 2}),
+                    Command.create({"name": "3", "sequence": 3}),
+                ],
+            }
+        )
+        (
+            cls.thing_attribute_1,
+            cls.thing_attribute_2,
+            cls.thing_attribute_3,
+        ) = cls.thing_attribute.value_ids
+
+        cls.shirt = cls.env["product.template"].create(
+            {
+                "name": "Shirt",
+                "attribute_line_ids": [
+                    Command.create(
+                        {
+                            "attribute_id": cls.size_attribute.id,
+                            "value_ids": [
+                                Command.set(cls.size_attribute.value_ids.ids)
+                            ],
+                        }
+                    ),
+                    Command.create(
+                        {
+                            "attribute_id": cls.colour_attribute.id,
+                            "value_ids": [
+                                Command.set(cls.colour_attribute.value_ids.ids)
+                            ],
+                        }
+                    ),
+                    Command.create(
+                        {
+                            "attribute_id": cls.thing_attribute.id,
+                            "value_ids": [
+                                Command.set(cls.thing_attribute.value_ids.ids)
+                            ],
+                        }
+                    ),
+                ],
+            }
+        )
+
+    def test_no_exclusion(self):
+        self.assertEqual(self.shirt.product_variant_count, 27)
+
+    def test_full_exclusion(self):
+        ptav_ids = self.env["product.template.attribute.value"]
+
+        for exclude in [
+            self.size_attribute_l,
+            self.color_attribute_blue,
+            self.thing_attribute_1,
+        ]:
+            ptav_ids |= self.env["product.template.attribute.value"].search(
+                [
+                    ("product_attribute_value_id", "=", exclude.id),
+                    ("product_tmpl_id", "=", self.shirt.id),
+                ]
+            )
+
+        self.assertEqual(len(ptav_ids), 3)
+
+        self.assertTrue(self.shirt._is_combination_possible(ptav_ids))
+
+        excl_ids = self.env["product.variant.exclusion"].create(
+            {"tmpl_id": self.shirt.id, "ptav_ids": [Command.set(ptav_ids.ids)]}
+        )
+        self.assertEqual(self.shirt.product_variant_count, 26)
+
+        self.assertFalse(self.shirt._is_combination_possible(ptav_ids))
+
+        excl_ids.unlink()
+        self.assertEqual(self.shirt.product_variant_count, 27)
+
+    def test_partial_exclusion(self):
+        ptav_exclude_id = self.env["product.template.attribute.value"].search(
+            [
+                ("product_attribute_value_id", "=", self.color_attribute_blue.id),
+                ("product_tmpl_id", "=", self.shirt.id),
+            ]
+        )
+
+        invalid_combination = self.env["product.template.attribute.value"].search(
+            [
+                (
+                    "product_attribute_value_id",
+                    "in",
+                    [
+                        self.color_attribute_blue.id,
+                        self.size_attribute_l.id,
+                        self.thing_attribute_1.id,
+                    ],
+                ),
+                ("product_tmpl_id", "=", self.shirt.id),
+            ]
+        )
+
+        self.assertTrue(self.shirt._is_combination_possible(invalid_combination))
+
+        excl_ids = self.env["product.variant.exclusion"].create(
+            {"tmpl_id": self.shirt.id, "ptav_ids": [Command.set(ptav_exclude_id.ids)]}
+        )
+        self.assertEqual(self.shirt.product_variant_count, 18)
+
+        self.assertFalse(self.shirt._is_combination_possible(invalid_combination))
+
+        excl_ids.unlink()
+        self.assertEqual(self.shirt.product_variant_count, 27)

--- a/product_variant_exclusion/views/product_template.xml
+++ b/product_variant_exclusion/views/product_template.xml
@@ -1,0 +1,42 @@
+<odoo>
+    <record id="product_template_only_form_view" model="ir.ui.view">
+        <field
+            name="name"
+        >product.template.product.form.inherit.product_data_feed</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="product.product_template_only_form_view" />
+        <field name="arch" type="xml">
+            <xpath expr="//notebook/page[@name='variants']" position="inside">
+                <group string="Exclusions">
+                    <group>
+                        <field
+                            name="product_variant_exclusion_ids"
+                            colspan="2"
+                            nolabel="1"
+                        >
+                            <list editable="bottom">
+                                <field name="ptav_ids" widget="many2many_tags" />
+                            </list>
+                        </field>
+                    </group>
+                    <group>
+                        <p class="oe_grey" colspan="2">
+                        <strong
+                        >Warning</strong>: Add a combination of attribute values to each line. Any product variant which contains ALL variant attributes will be archived or erased as an invalid combination.
+                        </p>
+                        <p class="oe_grey" colspan="2">
+                        <strong
+                        >Example</strong>: The product has the colour attribute, red, green and blue, and sizes 1, 2, 3 and 4.
+                        <br />
+                        Adding only red to an exclusion line will remove all red products.
+                        <br />
+                        Adding red and size 1 to an exclusion line removes only red and size 1.
+                        <br />
+                        Adding 2 lines (red, size 1 and red, size 2) removes both red size 1 and size 2.
+                        </p>
+                    </group>
+                </group>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Fixes GH185355

**Dependencies:**
- N/A

**ARL (Associated Risk Level):**
- [x] Low
- [ ] Medium
- [ ] High

**Type of change:**
- [ ] Forwardport / Backport
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

