### PR TITLE
Show variant_taxes_id on product_normal_form_view

### DIFF
--- a/product_variant_specific_tax_sale/views/product_product_views.xml
+++ b/product_variant_specific_tax_sale/views/product_product_views.xml
@@ -1,5 +1,34 @@
 <?xml version="1.0" ?>
 <odoo>
+    <record id="product_normal_form_view" model="ir.ui.view">
+        <field name="name">product.product.form</field>
+        <field name="model">product.product</field>
+        <field name="priority">99</field>
+        <field name="inherit_id" ref="product.product_normal_form_view" />
+        <field name="arch" type="xml">
+            <div name="list_price_uom" position="after">
+                <label for="variant_taxes_id" invisible="type == 'combo'" />
+                <div name="variant_taxes_div" class="o_row" invisible="type == 'combo'">
+                    <field
+                        name="variant_taxes_id"
+                        widget="many2many_tags"
+                        class="oe_inline"
+                        context="{
+                            'default_type_tax_use': 'sale',
+                            'search_default_sale': 1,
+                            'search_default_service': type == 'service',
+                            'search_default_goods': type == 'consu',
+                        }"
+                    />
+                </div>
+            </div>
+
+            <xpath expr="//field[@name='taxes_id']" position="attributes">
+                <attribute name="readonly">variant_taxes_id</attribute>
+            </xpath>
+        </field>
+    </record>
+
     <record id="product_variant_easy_edit_view" model="ir.ui.view">
         <field name="name">product.product.view.form.easy</field>
         <field name="model">product.product</field>


### PR DESCRIPTION
Makes `variant_taxes_id` visible on the product form accessed via the `Products - Product Variants` menu in Inventory, Sales etc.

View logic is based on https://github.com/odoo/odoo/blob/18.0/addons/account/views/product_view.xml#L76

Fixes GH185879

**Dependencies:**
- N/A

**ARL (Associated Risk Level):**
- [X] Low
- [ ] Medium
- [ ] High

**Type of change:**
- [ ] Forwardport / Backport
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

