### PR TITLE
Show variant_supplier_taxes_id on product_normal_form_view

### DIFF
--- a/product_variant_specific_tax_purchase/views/product_product_views.xml
+++ b/product_variant_specific_tax_purchase/views/product_product_views.xml
@@ -1,5 +1,30 @@
 <?xml version="1.0" ?>
 <odoo>
+    <record id="product_normal_form_view" model="ir.ui.view">
+        <field name="name">product.product.form</field>
+        <field name="model">product.product</field>
+        <field name="priority">99</field>
+        <field name="inherit_id" ref="product.product_normal_form_view" />
+        <field name="arch" type="xml">
+            <div name="standard_price_uom" position="after">
+                <field name="variant_supplier_taxes_id"
+                    invisible="not purchase_ok or type == 'combo'"
+                    widget="many2many_tags"
+                    context="{
+                        'default_type_tax_use':'purchase',
+                        'search_default_purchase': 1,
+                        'search_default_service': type == 'service',
+                        'search_default_goods': type == 'consu',
+                    }"
+                />
+            </div>
+
+            <xpath expr="//field[@name='supplier_taxes_id']" position="attributes">
+                <attribute name="readonly">variant_supplier_taxes_id</attribute>
+            </xpath>
+        </field>
+    </record>
+
     <record id="product_variant_easy_edit_view" model="ir.ui.view">
         <field name="name">product.product.view.form.easy</field>
         <field name="model">product.product</field>

--- a/product_variant_specific_tax_purchase/views/product_product_views.xml
+++ b/product_variant_specific_tax_purchase/views/product_product_views.xml
@@ -6,8 +6,9 @@
         <field name="priority">99</field>
         <field name="inherit_id" ref="product.product_normal_form_view" />
         <field name="arch" type="xml">
-            <div name="standard_price_uom" position="after">
-                <field name="variant_supplier_taxes_id"
+            <xpath expr="//field[@name='barcode']" position="after">
+                <field
+                    name="variant_supplier_taxes_id"
                     invisible="not purchase_ok or type == 'combo'"
                     widget="many2many_tags"
                     context="{
@@ -17,7 +18,7 @@
                         'search_default_goods': type == 'consu',
                     }"
                 />
-            </div>
+            </xpath>
 
             <xpath expr="//field[@name='supplier_taxes_id']" position="attributes">
                 <attribute name="readonly">variant_supplier_taxes_id</attribute>


### PR DESCRIPTION
Makes `variant_supplier_taxes_id` visible on the product form accessed via the `Products - Product Variants` menu in Inventory, Sales etc.

View logic is based on https://github.com/odoo/odoo/blob/18.0/addons/account/views/product_view.xml#L93

Fixes GH185879

**Dependencies:**
- N/A

**ARL (Associated Risk Level):**
- [X] Low
- [ ] Medium
- [ ] High

**Type of change:**
- [ ] Forwardport / Backport
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

