### PR TITLE
Replace create_date desc with id desc in EDI message and EDI envelope list views

### DIFF
--- a/connector_edi/views/edi_envelope_views.xml
+++ b/connector_edi/views/edi_envelope_views.xml
@@ -91,6 +91,7 @@
         <field name="model">edi.envelope</field>
         <field name="arch" type="xml">
             <list
+                default_order="id desc"
                 decoration-danger="state == 'error'"
                 decoration-success="state == 'done'"
             >

--- a/connector_edi/views/edi_envelope_views.xml
+++ b/connector_edi/views/edi_envelope_views.xml
@@ -91,7 +91,6 @@
         <field name="model">edi.envelope</field>
         <field name="arch" type="xml">
             <list
-                default_order="create_date desc"
                 decoration-danger="state == 'error'"
                 decoration-success="state == 'done'"
             >

--- a/connector_edi/views/edi_message_views.xml
+++ b/connector_edi/views/edi_message_views.xml
@@ -118,6 +118,7 @@
         <field name="model">edi.message</field>
         <field name="arch" type="xml">
             <list
+                default_order="id desc"
                 decoration-danger="state == 'error'"
                 decoration-success="state == 'done'"
             >

--- a/connector_edi/views/edi_message_views.xml
+++ b/connector_edi/views/edi_message_views.xml
@@ -118,7 +118,6 @@
         <field name="model">edi.message</field>
         <field name="arch" type="xml">
             <list
-                default_order="create_date desc"
                 decoration-danger="state == 'error'"
                 decoration-success="state == 'done'"
             >


### PR DESCRIPTION
This significantly decreases the load time of the list views on a customer DB with over 640,000 EDI envelope records and 27,000,000 EDI message records (>15s to <1s for the latter)

Ideally this would be moved into  `_order` at the model level but I'm not sure if there any `search` calls that are order-dependent

Fixes GH187262

**Dependencies:**
- N/A

**ARL (Associated Risk Level):**
- [X] Low
- [ ] Medium
- [ ] High

**Type of change:**
- [] Forwardport / Backport
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

