### PR TITLE
[FIX] Fix field reference in action_view_helpdesk_ticket_ids

### DIFF
--- a/helpdesk_purchase_order_link/models/purchase_order.py
+++ b/helpdesk_purchase_order_link/models/purchase_order.py
@@ -22,7 +22,7 @@ class PurchaseOrder(models.Model):
     def action_view_helpdesk_ticket_ids(self):
         self.ensure_one()
 
-        helpdesk_ticket_ids = self.mapped("helpdesk_tickets_ids").ids
+        helpdesk_ticket_ids = self.mapped("helpdesk_ticket_ids").ids
 
         action = {
             "res_model": "helpdesk.ticket",


### PR DESCRIPTION
`helpdesk_tickets_ids` is present in `helpdesk_sale_order_link` (which should probably be changed in a migration script for 19.0)

Assuming I copy-pasted this wrong when upgrading to 18.0 beforehand

**Dependencies:**
- N/A

**ARL (Associated Risk Level):**
- [X] Low
- [ ] Medium
- [ ] High

**Type of change:**
- [ ] Forwardport / Backport
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

