### PR TITLE
[IMP] GH187507 Add extra options to automate_customer_lead_time

### DIFF
--- a/automate_customer_lead_time/README.rst
+++ b/automate_customer_lead_time/README.rst
@@ -7,11 +7,14 @@ Odoo Standard Method:
 * Regardless of stock or vendor lead time, the customer lead time is used as the expected delivery date
 
 This Module:
-* Adds a field to each product to choose how to handle vendor lead time
+* Allows you to set a Customer Lead Time Method globally in Sales > Configuration
+- Standard Method: Use Default Odoo Behaviour. Only uses Customer lead time
+- Use Vendor Only: Use Vendor lead time only
 - Add: Customer lead time + Vendor lead time (Default)
-- Replace: Use Vendor lead time only
 - Max: Use the maximum of Customer lead time or Vendor lead time
 - Min: Use the minimum of Customer lead time or Vendor lead time
+* This can be overridden per product
+* Adds a field to each product to choose how to handle vendor lead time
 * When placing a sales order, the customer lead time is adjusted based on the selected method and the vendor lead time from the product's supplier info
 * The expected delivery date on the sales order line is updated accordingly, along with all related pickings
 

--- a/automate_customer_lead_time/README.rst
+++ b/automate_customer_lead_time/README.rst
@@ -23,5 +23,10 @@ when product quantity is changed on the sale order line. If the product is in st
 only the customer lead time is used, but if the product is out of stock, the vendor lead
 time is included based on the selected method.
 
-CAVEAT: There are some cases where manufacturable stock and its lead time will not be
+CAVEATS:
+* There are some cases where manufacturable stock and its lead time will not be
 taken into consideration. We plan to address this in a future update/glue module.
+* When calculating stock availability, we look at the virtual available stock as of the
+date of the sales order, EXCLUDING any incoming stock. This means that if you have
+incoming stock that will arrive before the shipping date, it will not be considered 
+when calculating the customer lead time.

--- a/automate_customer_lead_time/README.rst
+++ b/automate_customer_lead_time/README.rst
@@ -22,3 +22,6 @@ Vendor lead time is determined at the point of adding the product to the sales o
 when product quantity is changed on the sale order line. If the product is in stock,
 only the customer lead time is used, but if the product is out of stock, the vendor lead
 time is included based on the selected method.
+
+CAVEAT: There are some cases where manufacturable stock and its lead time will not be
+taken into consideration. We plan to address this in a future update/glue module.

--- a/automate_customer_lead_time/__manifest__.py
+++ b/automate_customer_lead_time/__manifest__.py
@@ -8,6 +8,7 @@
     "depends": ["sale_stock", "purchase_stock"],
     "data": [
         "views/product_template.xml",
+        "views/res_config_settings.xml",
     ],
     "demo": [],
     "license": "Other proprietary",

--- a/automate_customer_lead_time/models/__init__.py
+++ b/automate_customer_lead_time/models/__init__.py
@@ -1,1 +1,1 @@
-from . import product, sale_order_line
+from . import product, sale_order_line, res_company, res_config_settings

--- a/automate_customer_lead_time/models/res_company.py
+++ b/automate_customer_lead_time/models/res_company.py
@@ -1,24 +1,23 @@
 from odoo import fields, models
 
 
-class ProductTemplate(models.Model):
-    _inherit = "product.template"
+class ResCompany(models.Model):
+    _inherit = "res.company"
 
-    sale_delay_method = fields.Selection(
+    sale_lead_time_method = fields.Selection(
         [
-            ("default", "Company Default"),
-            ("customer", "Use Customer Only"),
+            ("customer", "Standard Method"),
             ("replace", "Use Vendor Only"),
             ("add", "Customer + Vendor"),
             ("max", "Max Customer v Vendor"),
             ("min", "Min Customer v Vendor"),
         ],
-        default="default",
+        default="customer",
         required=True,
-        string="Customer Lead Time Method",
+        string="Default Customer Lead Time Method",
         help="""Method to calculate the customer lead time based on vendor lead time.
-        - Company Default: Default behaviour set in Sales > Configuration
-        - Use Customer Only: Uses only the customer lead time.
+        Can be overridden per product.
+        - Standard Method: Standard Odoo behaviour. Uses only the customer lead time.
         - Use Vendor Only: Replaces the customer lead time with the vendor lead time.
         - Customer + Vendor: Adds the vendor lead time to the customer lead time.
         - Max Customer v Vendor: Use whichever is greater, customer or vendor lead time.

--- a/automate_customer_lead_time/models/res_config_settings.py
+++ b/automate_customer_lead_time/models/res_config_settings.py
@@ -1,0 +1,20 @@
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    sale_lead_time_method = fields.Selection(
+        related="company_id.sale_lead_time_method",
+        string="Customer Lead Time Method",
+        readonly=False,
+        required=True,
+        help="""Method to calculate the customer lead time based on vendor lead time.
+        Can be overridden per product.
+        - Standard Method: Standard Odoo behaviour. Uses only the customer lead time.
+        - Use Vendor Only: Replaces the customer lead time with the vendor lead time.
+        - Customer + Vendor: Adds the vendor lead time to the customer lead time.
+        - Max Customer v Vendor: Use whichever is greater, customer or vendor lead time.
+        - Min Customer v Vendor: Use whichever is least, customer or vendor lead time.
+        """,
+    )

--- a/automate_customer_lead_time/models/sale_order_line.py
+++ b/automate_customer_lead_time/models/sale_order_line.py
@@ -10,14 +10,20 @@ class SaleOrderLine(models.Model):
         # Adjust lead time to account for vendor time
         for line in self:
             product = line.product_id
+            delay_method = product.sale_delay_method if product else "default"
+            if delay_method == "default":
+                # Use the default method from sales settings
+                delay_method = self.env.company.sale_lead_time_method
+            if delay_method == "customer":
+                continue
             vendor_lead_time = line._get_vendor_lead_time()
-            if product.sale_delay_method == "add":
+            if delay_method == "add":
                 line.customer_lead += vendor_lead_time
-            elif product.sale_delay_method == "replace":
+            elif delay_method == "replace":
                 line.customer_lead = vendor_lead_time
-            elif product.sale_delay_method == "max":
+            elif delay_method == "max":
                 line.customer_lead = max(line.customer_lead, vendor_lead_time)
-            elif product.sale_delay_method == "min":
+            elif delay_method == "min":
                 line.customer_lead = min(line.customer_lead, vendor_lead_time)
         return res
 

--- a/automate_customer_lead_time/models/sale_order_line.py
+++ b/automate_customer_lead_time/models/sale_order_line.py
@@ -30,10 +30,15 @@ class SaleOrderLine(models.Model):
     def _get_vendor_lead_time(self):
         self.ensure_one()
         product = self.product_id
-        if not product or product.qty_available >= self.product_uom_qty:
+        if not product:
+            return 0.0
+        current_qty = product.with_context(
+            to_date=self.order_id.date_order
+        ).virtual_available
+        if current_qty >= self.product_uom_qty:
             return 0.0
         seller = product._select_seller(
-            quantity=self.product_uom_qty,
+            quantity=self.product_uom_qty - current_qty,
             date=self.order_id.date_order and self.order_id.date_order.date(),
             uom_id=self.product_uom,
         )

--- a/automate_customer_lead_time/models/sale_order_line.py
+++ b/automate_customer_lead_time/models/sale_order_line.py
@@ -32,11 +32,11 @@ class SaleOrderLine(models.Model):
         product = self.product_id
         if not product:
             return 0.0
-        current_qty = product.with_context(
-            to_date=self.order_id.date_order
-        ).virtual_available
+        current_qty = product.virtual_available - product.incoming_qty
         if current_qty >= self.product_uom_qty:
+            # We can ship it 'today'
             return 0.0
+        # We will most likely need to order it
         seller = product._select_seller(
             quantity=self.product_uom_qty - current_qty,
             date=self.order_id.date_order and self.order_id.date_order.date(),

--- a/automate_customer_lead_time/tests/test_automate_customer_lead_time.py
+++ b/automate_customer_lead_time/tests/test_automate_customer_lead_time.py
@@ -181,3 +181,50 @@ class TestAutomateLeadTime(TransactionCase):
         )
         sale_line = sale_order.order_line[0]
         self.assertEqual(sale_line.customer_lead, 5)  # Customer lead time only
+
+    def test_reserved_stock_lead_time(self):
+        self.product_id.sale_delay_method = "add"
+        self.env["stock.quant"].create(
+            {
+                "product_id": self.product_id.product_variant_id.id,
+                "location_id": self.env.ref("stock.stock_location_stock").id,
+                "quantity": 1,  # Only 1 in stock
+            }
+        )
+        sale_order_1 = self.env["sale.order"].create(
+            {
+                "partner_id": self.partner_id.id,
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": self.product_id.product_variant_id.id,
+                            "product_uom_qty": 1,
+                            "price_unit": 100.0,
+                        },
+                    )
+                ],
+            }
+        )
+        sale_line_1 = sale_order_1.order_line[0]
+        self.assertEqual(sale_line_1.customer_lead, 5)  # Customer lead time only
+        sale_order_1.action_confirm()  # Reserve the only stock
+        sale_order_2 = self.env["sale.order"].create(
+            {
+                "partner_id": self.partner_id.id,
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": self.product_id.product_variant_id.id,
+                            "product_uom_qty": 1,
+                            "price_unit": 100.0,
+                        },
+                    )
+                ],
+            }
+        )
+        sale_line = sale_order_2.order_line[0]
+        self.assertEqual(sale_line.customer_lead, 15)  # 5 + 10

--- a/automate_customer_lead_time/tests/test_automate_customer_lead_time.py
+++ b/automate_customer_lead_time/tests/test_automate_customer_lead_time.py
@@ -1,3 +1,5 @@
+import datetime
+
 from odoo.tests.common import TransactionCase
 
 
@@ -228,3 +230,24 @@ class TestAutomateLeadTime(TransactionCase):
         )
         sale_line = sale_order_2.order_line[0]
         self.assertEqual(sale_line.customer_lead, 15)  # 5 + 10
+
+        # Add incoming stock that arrives before the supplier lead time
+        self.env["purchase.order"].create(
+            {
+                "partner_id": self.seller.id,
+                "date_order": datetime.datetime.now(),
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": self.product_id.product_variant_id.id,
+                            "product_qty": 20,  # Ample stock
+                            "price_unit": 100.0,
+                        },
+                    )
+                ],
+            }
+        ).button_confirm()
+        sale_line._compute_customer_lead()
+        self.assertEqual(sale_line.customer_lead, 15)  # Incoming stock ignored

--- a/automate_customer_lead_time/tests/test_automate_customer_lead_time.py
+++ b/automate_customer_lead_time/tests/test_automate_customer_lead_time.py
@@ -27,6 +27,49 @@ class TestAutomateLeadTime(TransactionCase):
             }
         )
 
+    def test_lead_time_default_method(self):
+        self.product_id.sale_delay_method = "default"
+        sale_order = self.env["sale.order"].create(
+            {
+                "partner_id": self.partner_id.id,
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": self.product_id.product_variant_id.id,
+                            "product_uom_qty": 1,
+                            "price_unit": 100.0,
+                        },
+                    )
+                ],
+            }
+        )
+        sale_line = sale_order.order_line[0]
+        self.assertEqual(sale_line.customer_lead, 5)
+
+    def test_lead_time_default_add_method(self):
+        self.env.company.sale_lead_time_method = "add"
+        self.product_id.sale_delay_method = "default"
+        sale_order = self.env["sale.order"].create(
+            {
+                "partner_id": self.partner_id.id,
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": self.product_id.product_variant_id.id,
+                            "product_uom_qty": 1,
+                            "price_unit": 100.0,
+                        },
+                    )
+                ],
+            }
+        )
+        sale_line = sale_order.order_line[0]
+        self.assertEqual(sale_line.customer_lead, 15)  # 5 + 10
+
     def test_lead_time_add_method(self):
         self.product_id.sale_delay_method = "add"
         sale_order = self.env["sale.order"].create(

--- a/automate_customer_lead_time/tests/test_automate_customer_lead_time.py
+++ b/automate_customer_lead_time/tests/test_automate_customer_lead_time.py
@@ -113,7 +113,13 @@ class TestAutomateLeadTime(TransactionCase):
 
     def test_product_in_stock_lead_time(self):
         self.product_id.sale_delay_method = "add"
-        self.product_id.qty_available = 10  # Simulate stock available
+        self.env["stock.quant"].create(
+            {
+                "product_id": self.product_id.product_variant_id.id,
+                "location_id": self.env.ref("stock.stock_location_stock").id,
+                "quantity": 100,  # Sufficient stock available
+            }
+        )
         sale_order = self.env["sale.order"].create(
             {
                 "partner_id": self.partner_id.id,

--- a/automate_customer_lead_time/views/res_config_settings.xml
+++ b/automate_customer_lead_time/views/res_config_settings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="res_config_settings_view_form" model="ir.ui.view">
+        <field name="name">res_config_settings_view_form</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="sale.res_config_settings_view_form" />
+        <field name="arch" type="xml">
+            <block name="quotation_order_setting_container" position="inside">
+                <setting
+                    id="sale_lead_time_configuration"
+                    string="Customer Lead Time Method"
+                >
+                    <field name="sale_lead_time_method" />
+                    <div class="text-muted">
+                        <p>
+                            Method to calculate the customer lead time based on vendor lead time. Can be overridden per product.
+                        </p>
+                        <ul>
+                            <li><strong
+                            >Standard Method</strong>: Default Odoo Behaviour. Uses only the customer lead time.</li>
+                            <li><strong
+                            >Use Vendor Only</strong>: Replaces the customer lead time with the vendor lead time.</li>
+                            <li><strong
+                            >Customer + Vendor</strong>: Adds the vendor lead time to the customer lead time.</li>
+                            <li><strong
+                            >Max Customer v Vendor</strong>: Use whichever is greater, customer or vendor lead time.</li>
+                            <li><strong
+                            >Min Customer v Vendor</strong>: Use whichever is least, customer or vendor lead time.</li>
+                        </ul>
+                    </div>
+                </setting>
+            </block>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Fixes GH187507

**Dependencies:**
- N/A

**ARL (Associated Risk Level):**
- [x] Low
- [ ] Medium
- [ ] High

**Type of change:**
- [ ] Forwardport / Backport
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

<img width="431" height="335" alt="image" src="https://github.com/user-attachments/assets/27e1c33d-3017-4c25-9923-5810116ae9ef" />

<img width="409" height="259" alt="image" src="https://github.com/user-attachments/assets/3ed510a8-d9cd-47e4-af63-70fd020544e7" />

Example: Using the "Customer + Vendor" method. Vendor record set to 30 days lead time, Customer Lead time set to 2 days. Total lead time is 32 days. Order date 30/09/2025:

<img width="612" height="93" alt="image" src="https://github.com/user-attachments/assets/96d81b15-6250-4c88-a02e-9dad865333eb" />

<img width="603" height="41" alt="image" src="https://github.com/user-attachments/assets/9045a017-07a2-475a-bb22-c2c313c5f111" />
