### PR TITLE
[GH189812][FIX] Remove _name_search override

### DIFF
--- a/cpq/models/product_template.py
+++ b/cpq/models/product_template.py
@@ -2,7 +2,6 @@ import copy
 
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError, ValidationError
-from odoo.osv import expression
 from odoo.tools import (
     format_amount,
     format_date,

--- a/cpq/models/product_template.py
+++ b/cpq/models/product_template.py
@@ -59,26 +59,6 @@ class ProductTemplate(models.Model):
     )
     cpq_tooltip = fields.Html(compute="_compute_cpq_tooltip")
 
-    @api.model
-    def _name_search(
-        self, name, args=None, operator="ilike", limit=100, name_get_uid=None
-    ):
-        args = args or []
-        domain = []
-        if name:
-            domain = [
-                "|",
-                "|",
-                ("cpq_ref", operator, name),
-                ("default_code", operator, name),
-                ("name", operator, name),
-            ]
-            if operator in expression.NEGATIVE_TERM_OPERATORS:
-                domain = ["&", "!"] + domain[1:]
-        return super()._name_search(
-            name, expression.AND([domain, args]), operator, limit, name_get_uid
-        )
-
     def _cpq_tooltip_items(self):
         self.ensure_one()
         return [

--- a/cpq/models/product_template.py
+++ b/cpq/models/product_template.py
@@ -66,7 +66,13 @@ class ProductTemplate(models.Model):
         args = args or []
         domain = []
         if name:
-            domain = ["|", ("cpq_ref", operator, name), ("name", operator, name)]
+            domain = [
+                "|",
+                "|",
+                ("cpq_ref", operator, name),
+                ("default_code", operator, name),
+                ("name", operator, name),
+            ]
             if operator in expression.NEGATIVE_TERM_OPERATORS:
                 domain = ["&", "!"] + domain[1:]
         return super()._name_search(


### PR DESCRIPTION
This is incompatible with how core Odoo works (doesn't search by `default_code`)

We've removed the override for pragmatic reasons.

Fixes GH189812

**ARL (Associated Risk Level):**
- [X] Low
- [ ] Medium
- [ ] High

**Type of change:**
- [ ] Forwardport / Backport
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

