### PR TITLE
[18.0][ADD] forwardport_stock_mts_else_mto_link

### DIFF
--- a/.ci/entrypoint.d/01_bootstrap_database
+++ b/.ci/entrypoint.d/01_bootstrap_database
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 ADDONS=$(manifestoo --select-addons-dir src/private list --separator=, --sort=topological)
-odoo -d ${PGDATABASE} -i ${ADDONS} --stop-after-init --max-cron-threads=0
+odoo -d ${PGDATABASE} -i ${ADDONS} --stop-after-init --max-cron-threads=0 --unaccent

--- a/.ci/entrypoint.d/03_run_tests
+++ b/.ci/entrypoint.d/03_run_tests
@@ -5,4 +5,5 @@ unbuffer odoo \
     -d ${PGDATABASE} \
     -i ${ADDONS} \
     --test-enable \
+    --unaccent \
     --stop-after-init | checklog-odoo -c src/private/.checklog-odoo

--- a/forwardport_stock_mts_else_mto_link/README.md
+++ b/forwardport_stock_mts_else_mto_link/README.md
@@ -1,0 +1,7 @@
+# forwardport_stock_mts_else_mto_link
+
+:warning: This module may have unforeseen consequences. Do not enter into this lightly.
+We have not fully understood the impact of this module, nor written tests for this
+module.
+
+Reverts the behaviour changed in Odoo where mts_else_mto orders are not fully linked.

--- a/forwardport_stock_mts_else_mto_link/README.md
+++ b/forwardport_stock_mts_else_mto_link/README.md
@@ -1,7 +1,6 @@
 # forwardport_stock_mts_else_mto_link
 
-:warning: This module may have unforeseen consequences. Do not enter into this lightly.
-We have not fully understood the impact of this module, nor written tests for this
-module.
+⚠️ This module may have unforeseen consequences. Do not enter into this lightly. We have
+not fully understood the impact of this module, nor written tests for this module.
 
 Reverts the behaviour changed in Odoo where mts_else_mto orders are not fully linked.

--- a/forwardport_stock_mts_else_mto_link/__init__.py
+++ b/forwardport_stock_mts_else_mto_link/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/forwardport_stock_mts_else_mto_link/__manifest__.py
+++ b/forwardport_stock_mts_else_mto_link/__manifest__.py
@@ -1,0 +1,11 @@
+{
+    "name": "forwardport_stock_mts_else_mto_link",
+    "summary": "Reverts the behaviour changed in Odoo where mts_else_mto orders are not"
+    " fully linked",
+    "author": "Glo Networks",
+    "website": "https://github.com/GlodoUK/odoo-addons",
+    "category": "Uncategorized",
+    "version": "18.0.1.0.0",
+    "depends": ["stock"],
+    "license": "Other proprietary",
+}

--- a/forwardport_stock_mts_else_mto_link/models/__init__.py
+++ b/forwardport_stock_mts_else_mto_link/models/__init__.py
@@ -1,0 +1,1 @@
+from . import stock_move

--- a/forwardport_stock_mts_else_mto_link/models/stock_move.py
+++ b/forwardport_stock_mts_else_mto_link/models/stock_move.py
@@ -1,0 +1,17 @@
+from odoo import models
+
+
+class StockMove(models.Model):
+    _inherit = "stock.move"
+
+    def _prepare_procurement_values(self):
+        res = super()._prepare_procurement_values()
+        if (
+            self.procure_method in ("make_to_order", "mts_else_mto")
+            or (
+                self.rule_id.procure_method == "mts_else_mto"
+                and self.procure_method not in ("make_to_order", "mts_else_mto")
+            )
+        ) and not res.get("move_dest_ids"):
+            res.update({"move_dest_ids": self})
+        return res

--- a/forwardport_stock_mts_else_mto_link/pyproject.toml
+++ b/forwardport_stock_mts_else_mto_link/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["whool"]
+build-backend = "whool.buildapi"

--- a/stock_available_sale_stock/static/src/widgets/quantity_at_date_widget.esm.js
+++ b/stock_available_sale_stock/static/src/widgets/quantity_at_date_widget.esm.js
@@ -1,5 +1,5 @@
-import {patch} from "@web/core/utils/patch";
 import {QtyAtDateWidget} from "@sale_stock/widgets/qty_at_date_widget";
+import {patch} from "@web/core/utils/patch";
 import {roundDecimals} from "@web/core/utils/numbers";
 
 patch(QtyAtDateWidget.prototype, {


### PR DESCRIPTION
Partial revert of mts_else_mto behaviour introduced as part of: https://github.com/odoo/odoo/commit/a72382063ee662010729d983fbf6fb6305b8adf2#diff-55c6314416a6a400da6acd5018d161a55eeeb0e3008fec8828121e3dd12be0ebR1582-R1584

:warning: There is unknown risk here

Fixes GH192635

**Dependencies:**
- N/A

**ARL (Associated Risk Level):**
- [ ] Low
- [ ] Medium
- [x] High

**Type of change:**
- [x] Forwardport / Backport
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

