### PR TITLE
[GH198606][FIX] Use _get_html_link() on _run(), _run_file()

### DIFF
--- a/connector_edi/components/route_export_file.py
+++ b/connector_edi/components/route_export_file.py
@@ -55,14 +55,11 @@ class EdiRouteFileExporterComponent(Component, MixinSafeFormatPath, MixinJobFrom
         job = self._job_from_ctx()
         if job:
             msg = _(
-                "Job <a href=# data-oe-model=queue.job"
-                " data-oe-id=%(job_id)d>%(job_uuid)s</a> wrote %(file)s"
-            ) % {
-                "job_id": job.id,
-                "job_uuid": job.uuid,
-                "file": file,
-            }
+                "Job %(job)s wrote %(file)s",
+                job=job._get_html_link(title=job.uuid),
+                file=file,
+            )
         else:
-            msg = _("Wrote file %(file)s") % {"file": file}
+            msg = _("Wrote file %s", file)
 
         envelope_id.action_done(msg)

--- a/connector_edi/components/route_import_file.py
+++ b/connector_edi/components/route_import_file.py
@@ -48,11 +48,12 @@ class EdiRouteFileImporterComponent(
             job = self._job_from_ctx()
             if job:
                 msg = _(
-                    "Job <a href=# data-oe-model=queue.job"
-                    " data-oe-id=%(job_id)d>%(job_uuid)s</a> read %(file)s"
-                ) % {"job_id": job.id, "job_uuid": job.uuid, "file": file}
+                    "Job %(job)s read %(file)s",
+                    job=job._get_html_link(title=job.uuid),
+                    file=file,
+                )
             else:
-                msg = _("Read file %s") % (file,)
+                msg = _("Read file %s", file)
 
             envelope_id.message_post(body=msg)
             return envelope_id


### PR DESCRIPTION
This irked me. Fixes malformed links.

Fixes GH198606

**Dependencies:**
- N/A

**ARL (Associated Risk Level):**
- [X] Low
- [ ] Medium
- [ ] High

**Type of change:**
- [ ] Forwardport / Backport
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

