### PR TITLE
[15.0][ADD] stock_location_freeze, stock_barcode_putaway_rules, backport_stock_removal_least_packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ addon | version | maintainers | summary
 [account_payment_better_matching](account_payment_better_matching/) | 15.0.1.1.0 |  | A better interface for bulk, but manual payment matching
 [account_payment_better_matching_queued](account_payment_better_matching_queued/) | 15.0.1.0.0 |  | Adds queued support to account_payment_better_matching
 [auth_signup_optional_notify](auth_signup_optional_notify/) | 15.0.1.0.0 |  | Optionally disable the notification on user login
+[backport_stock_barcode_manual_scan](backport_stock_barcode_manual_scan/) | 15.0.1.0.0 |  | Manually scan a barcode
 [backport_stock_removal_least_packages](backport_stock_removal_least_packages/) | 15.0.1.0.0 |  | Backport 'least packages' stock removal strategy
 [brands](brands/) | 15.0.2.0.0 |  | Allows a sale order and product to be associated with a brand
 [brands_crm](brands_crm/) | 15.0.0.1.0 |  | Allows a CRM entry to be associated with a brand

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ addon | version | maintainers | summary
 [account_payment_better_matching](account_payment_better_matching/) | 15.0.1.1.0 |  | A better interface for bulk, but manual payment matching
 [account_payment_better_matching_queued](account_payment_better_matching_queued/) | 15.0.1.0.0 |  | Adds queued support to account_payment_better_matching
 [auth_signup_optional_notify](auth_signup_optional_notify/) | 15.0.1.0.0 |  | Optionally disable the notification on user login
+[backport_stock_removal_least_packages](backport_stock_removal_least_packages/) | 15.0.1.0.0 |  | Backport 'least packages' stock removal strategy
 [brands](brands/) | 15.0.2.0.0 |  | Allows a sale order and product to be associated with a brand
 [brands_crm](brands_crm/) | 15.0.0.1.0 |  | Allows a CRM entry to be associated with a brand
 [brands_sale_stock](brands_sale_stock/) | 15.0.0.1.0 |  | Integrates sale_stock with brands
@@ -81,6 +82,8 @@ addon | version | maintainers | summary
 [sale_stock_force_pdf_download](sale_stock_force_pdf_download/) | 15.0.1.0.0 |  | Sale Stock Force PDF Download
 [sendgrid](sendgrid/) | 15.0.1.0.0 |  | Handle Inbound Email through Sendgrid Webhooks
 [stock_available_sale_stock](stock_available_sale_stock/) | 15.0.1.0.0 |  | Integrates stock_available and sale_stock
+[stock_barcode_putaway_rules](stock_barcode_putaway_rules/) | 15.0.1.0.0 |  | Add a button on the barcode app to evaluate putaway rules
+[stock_location_freeze](stock_location_freeze/) | 15.0.1.0.2 |  | Prevent further movements of stock in a given location
 [stock_picking_component_events](stock_picking_component_events/) | 15.0.1.0.0 |  | Stock Picking Component Events
 [stock_picking_hold](stock_picking_hold/) | 15.0.2.0.0 |  | Adds a custom hold state to stock.pickings which prevents deliveries from being processed
 [stock_picking_move_form](stock_picking_move_form/) | 15.0.1.0.0 |  | Adds a button to the stock.picking form view to easily show the stock.move form

--- a/backport_stock_barcode_manual_scan/README.rst
+++ b/backport_stock_barcode_manual_scan/README.rst
@@ -1,0 +1,21 @@
+==============================
+backport_stock_barcode_manual_scan
+==============================
+
+Adds a manual barcode entry button to the stock barcode interface, allowing
+users to type barcodes via keyboard when a hardware scanner is unavailable.
+
+- A keyboard icon button is injected next to the mobile scanner button in the
+  barcode UI.
+- Clicking the button opens a prompt dialog for manual barcode input.
+- The entered barcode is passed through the standard ``processBarcode()``
+  pipeline, so all existing barcode logic applies.
+
+Usage
+=====
+
+1. Open any stock barcode operation (e.g. a receipt, delivery, or inventory).
+2. Click the **keyboard icon** button in the header toolbar.
+3. Type the barcode and confirm.
+
+The barcode is processed identically to one scanned by a hardware device.

--- a/backport_stock_barcode_manual_scan/__manifest__.py
+++ b/backport_stock_barcode_manual_scan/__manifest__.py
@@ -1,0 +1,17 @@
+{
+    "name": "backport_stock_barcode_manual_scan",
+    "summary": "Manually scan a barcode",
+    "author": "Glo Networks",
+    "website": "https://github.com/GlodoUK/odoo-addons",
+    "version": "15.0.1.0.0",
+    "depends": ["stock_barcode"],
+    "assets": {
+        "web.assets_backend": [
+            "backport_stock_barcode_manual_scan/static/src/**/*.js",
+        ],
+        "web.assets_qweb": [
+            "backport_stock_barcode_manual_scan/static/src/**/*.xml",
+        ],
+    },
+    "license": "Other proprietary",
+}

--- a/backport_stock_barcode_manual_scan/pyproject.toml
+++ b/backport_stock_barcode_manual_scan/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["whool"]
+build-backend = "whool.buildapi"

--- a/backport_stock_barcode_manual_scan/static/src/components/main.esm.js
+++ b/backport_stock_barcode_manual_scan/static/src/components/main.esm.js
@@ -1,0 +1,13 @@
+/** @odoo-module **/
+
+import MainComponent from "@stock_barcode/components/main";
+import {patch} from "web.utils";
+
+patch(MainComponent.prototype, "backport_stock_barcode_manual_scan", {
+    barcodeManualScan() {
+        const barcode = window.prompt("Enter a barcode"); // eslint-disable-line no-alert
+        if (barcode !== null) {
+            this.env.model.processBarcode(barcode.trim());
+        }
+    },
+});

--- a/backport_stock_barcode_manual_scan/static/src/components/main.xml
+++ b/backport_stock_barcode_manual_scan/static/src/components/main.xml
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='utf-8' ?>
+<templates id="template" xml:space="preserve">
+    <t t-inherit="stock_barcode.MainComponent" t-inherit-mode="extension" owl="1">
+        <xpath expr="//button[@t-if='mobileScanner']" position="after">
+            <button
+                class="backport_stock_barcode_manual_scan btn nav-link"
+                t-on-click="barcodeManualScan"
+            >
+                <i class="fa fa-keyboard-o" />
+            </button>
+        </xpath>
+    </t>
+</templates>

--- a/backport_stock_removal_least_packages/README.rst
+++ b/backport_stock_removal_least_packages/README.rst
@@ -1,0 +1,39 @@
+=====================================
+backport_stock_removal_least_packages
+=====================================
+
+.. WARNING::
+   USE AT YOUR OWN RISK
+   This module is a best effort BACKPORT of functionality from a later Odoo version
+   Test thoroughly in a non-production environment before deploying.
+
+Backports the **Least Packages** stock removal strategy from **Odoo 17.0**
+version to **Odoo 15.0**.
+
+When this removal strategy is assigned to a product or location, Odoo will
+try to fulfil reservations using the **fewest number of packages** possible,
+rather than consuming packages one-by-one. This reduces package fragmentation
+and helps keep warehouse operations clean.
+
+Usage
+=====
+
+Setting the Removal Strategy
+-----------------------------
+
+1. Navigate to **Inventory > Configuration > Locations** (or open a product's
+   storage configuration).
+2. Set the **Removal Strategy** field to **Least Packages**.
+
+Once set, any stock reservation for products in that location will use the
+least-packages algorithm when calculating which quants to reserve.
+
+Limitations
+===========
+
+- This is a best-effort backport. Expect slight behavioural differences with 17.0+.
+- The A* search has a memory guard; very large package sets may fall back to
+  default behaviour.
+- The removal strategy order returned by ``_get_removal_strategy_order`` is a
+  placeholder (``in_date ASC``) and is not fully respected during reservation
+  — the A* result determines actual quant selection.

--- a/backport_stock_removal_least_packages/__init__.py
+++ b/backport_stock_removal_least_packages/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/backport_stock_removal_least_packages/__manifest__.py
+++ b/backport_stock_removal_least_packages/__manifest__.py
@@ -1,0 +1,13 @@
+{
+    "name": "backport_stock_removal_least_packages",
+    "summary": "Backport 'least packages' stock removal strategy",
+    "author": "Glo Networks",
+    "website": "https://github.com/GlodoUK/odoo-addons",
+    "category": "Uncategorized",
+    "version": "15.0.1.0.0",
+    "depends": ["stock"],
+    "data": [
+        "data/product_removal.xml",
+    ],
+    "license": "LGPL-3",
+}

--- a/backport_stock_removal_least_packages/data/product_removal.xml
+++ b/backport_stock_removal_least_packages/data/product_removal.xml
@@ -1,0 +1,7 @@
+<?xml version='1.0' encoding='utf-8' ?>
+<odoo noupdate="1">
+    <record id="removal_least_packages" model="product.removal">
+        <field name="name">Least Packages</field>
+        <field name="method">least_packages</field>
+    </record>
+</odoo>

--- a/backport_stock_removal_least_packages/models/__init__.py
+++ b/backport_stock_removal_least_packages/models/__init__.py
@@ -1,0 +1,1 @@
+from . import stock_quant

--- a/backport_stock_removal_least_packages/models/stock_quant.py
+++ b/backport_stock_removal_least_packages/models/stock_quant.py
@@ -1,0 +1,255 @@
+import heapq
+import logging
+from collections import namedtuple
+
+from odoo import api, models
+from odoo.osv import expression
+
+_logger = logging.getLogger(__name__)
+
+
+class StockQuant(models.Model):
+    _inherit = "stock.quant"
+
+    @api.model
+    def _get_removal_strategy_order(self, removal_strategy):
+        # XXX: This is a fudge, its not actually considered when reserving stock
+        if removal_strategy == "least_packages":
+            return "in_date ASC, id"
+        return super()._get_removal_strategy_order(removal_strategy)
+
+    @api.model
+    def _update_reserved_quantity(
+        self,
+        product_id,
+        location_id,
+        quantity,
+        lot_id=None,
+        package_id=None,
+        owner_id=None,
+        strict=False,
+    ):
+        self = self.sudo()
+        backport_stock_removal_least_packages = False
+        removal_strategy = self._get_removal_strategy(product_id, location_id)
+        if removal_strategy == "least_packages":
+            backport_stock_removal_least_packages = quantity
+
+        return super(
+            StockQuant,
+            self.with_context(
+                backport_stock_removal_least_packages=backport_stock_removal_least_packages
+            ),
+        )._update_reserved_quantity(
+            product_id,
+            location_id,
+            quantity,
+            lot_id=lot_id,
+            package_id=package_id,
+            owner_id=owner_id,
+            strict=strict,
+        )
+
+    def _gather(
+        self,
+        product_id,
+        location_id,
+        lot_id=None,
+        package_id=None,
+        owner_id=None,
+        strict=False,
+    ):
+        removal_strategy = self._get_removal_strategy(product_id, location_id)
+        if removal_strategy == "least_packages" and isinstance(
+            self.env.context.get("backport_stock_removal_least_packages"), float
+        ):
+            domain = [("product_id", "=", product_id.id)]
+            if not strict:
+                if lot_id:
+                    domain = expression.AND(
+                        [
+                            ["|", ("lot_id", "=", lot_id.id), ("lot_id", "=", False)],
+                            domain,
+                        ]
+                    )
+                if package_id:
+                    domain = expression.AND(
+                        [[("package_id", "=", package_id.id)], domain]
+                    )
+                if owner_id:
+                    domain = expression.AND([[("owner_id", "=", owner_id.id)], domain])
+                domain = expression.AND(
+                    [[("location_id", "child_of", location_id.id)], domain]
+                )
+            else:
+                domain = expression.AND(
+                    [
+                        ["|", ("lot_id", "=", lot_id.id), ("lot_id", "=", False)]
+                        if lot_id
+                        else [("lot_id", "=", False)],
+                        domain,
+                    ]
+                )
+                domain = expression.AND(
+                    [
+                        [("package_id", "=", package_id and package_id.id or False)],
+                        domain,
+                    ]
+                )
+                domain = expression.AND(
+                    [[("owner_id", "=", owner_id and owner_id.id or False)], domain]
+                )
+                domain = expression.AND(
+                    [[("location_id", "=", location_id.id)], domain]
+                )
+
+            qty = self.env.context.get("backport_stock_removal_least_packages")
+            domain, order = (
+                self._backport_run_least_packages_removal_strategy_astar(domain, qty),
+                "in_date ASC, id",
+            )
+            return self.search(domain, order=order)
+
+        return super()._gather(
+            product_id,
+            location_id,
+            lot_id=lot_id,
+            package_id=package_id,
+            owner_id=owner_id,
+            strict=strict,
+        )
+
+    def _backport_run_least_packages_removal_strategy_astar(self, domain, qty):  # noqa: C901
+        # Fetch the available packages and contents
+        query = self._where_calc(domain)
+        query_str, params = query.select(
+            "package_id", "SUM(quantity - reserved_quantity) AS available_qty"
+        )
+        query_str += " GROUP BY package_id HAVING SUM(quantity - reserved_quantity) > 0 ORDER BY available_qty DESC"  # noqa: E501
+        self._cr.execute(query_str, params)
+        qty_by_package = self._cr.fetchall()
+
+        # Items that do not belong to a package are added individually to the list, any
+        # empty packages get removed.
+        pkg_found = False
+        new_qty_by_package = []
+        none_elements = []
+
+        for elem in qty_by_package:
+            if elem[0] is None:
+                none_elements.extend([(None, 1) for _ in range(int(elem[1]))])
+            elif elem[1] != 0:
+                new_qty_by_package.append(elem)
+                pkg_found = True
+
+        new_qty_by_package.extend(none_elements)
+        qty_by_package = new_qty_by_package
+
+        if not pkg_found:
+            return domain
+        size = len(qty_by_package)
+
+        class PriorityQueue:
+            def __init__(self):
+                self.elements = []
+
+            def empty(self) -> bool:
+                return not self.elements
+
+            def put(self, item, priority):
+                heapq.heappush(self.elements, (priority, item))
+
+            def get(self):
+                return heapq.heappop(self.elements)[1]
+
+        def heuristic(node):
+            if node.next_index < size:
+                return (
+                    len(node.taken_packages)
+                    + node.count_remaining / qty_by_package[node.next_index][1]
+                )
+            return len(node.taken_packages)
+
+        def generate_domain(node):
+            selected_single_items = []
+            single_item_ids = False
+            for pkg in node.taken_packages:
+                if pkg[0] is None:
+                    # Lazily retrieve ids for single items
+                    if not single_item_ids:
+                        single_item_ids = self.search(
+                            expression.AND([[("package_id", "=", None)], domain])
+                        ).mapped("id")
+                    selected_single_items.append(single_item_ids.pop())
+
+            expr = [
+                (
+                    "package_id",
+                    "in",
+                    [elem[0] for elem in node.taken_packages if elem[0] is not None],
+                )
+            ]
+            if selected_single_items:
+                expr = expression.OR([expr, [("id", "in", selected_single_items)]])
+            return expression.AND([expr, domain])
+
+        Node = namedtuple("Node", "count_remaining taken_packages next_index")
+
+        frontier = PriorityQueue()
+        frontier.put(Node(qty, (), 0), 0)
+
+        best_leaf = Node(qty, (), 0)
+
+        try:
+            while not frontier.empty():
+                current = frontier.get()
+
+                if current.count_remaining <= 0:
+                    return generate_domain(current)
+
+                # Keep track of processed package amounts to only generate one branch
+                # for the same amount
+                last_count = None
+                i = current.next_index
+                while i < size:
+                    pkg = qty_by_package[i]
+                    i += 1
+                    if pkg[1] == last_count:
+                        continue
+                    last_count = pkg[1]
+
+                    count = current.count_remaining - pkg[1]
+                    taken = current.taken_packages + (pkg,)
+                    node = Node(count, taken, i)
+
+                    if count < 0:
+                        # Overselect case
+                        if (
+                            best_leaf.count_remaining > 0
+                            or len(node.taken_packages) < len(best_leaf.taken_packages)
+                            or (
+                                len(node.taken_packages)
+                                == len(best_leaf.taken_packages)
+                                and node.count_remaining > best_leaf.count_remaining
+                            )
+                        ):
+                            best_leaf = node
+                        continue
+
+                    if i >= size and count != 0:
+                        # Not enough packages case
+                        if node.count_remaining < best_leaf.count_remaining:
+                            best_leaf = node
+                        continue
+
+                    frontier.put(node, heuristic(node))
+        except MemoryError:
+            _logger.info(
+                "Ran out of memory while trying to use the least_packages strategy to"
+                " get quants. Domain: %s",
+                domain,
+            )
+            return domain
+
+        # no exact matching possible, use best leaf
+        return generate_domain(best_leaf)

--- a/backport_stock_removal_least_packages/pyproject.toml
+++ b/backport_stock_removal_least_packages/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["whool"]
+build-backend = "whool.buildapi"

--- a/backport_stock_removal_least_packages/tests/__init__.py
+++ b/backport_stock_removal_least_packages/tests/__init__.py
@@ -1,0 +1,3 @@
+from . import test_least_packages
+
+from . import test_upstream

--- a/backport_stock_removal_least_packages/tests/test_least_packages.py
+++ b/backport_stock_removal_least_packages/tests/test_least_packages.py
@@ -1,0 +1,248 @@
+from odoo.tests import TransactionCase
+
+
+class StockQuantRemovalStrategy(TransactionCase):
+    def setUp(self):
+        super().setUp()
+        self.least_package_strategy = self.env.ref(
+            "backport_stock_removal_least_packages.removal_least_packages"
+        )
+        self.product = self.env["product.product"].create(
+            {
+                "name": "Product",
+                "type": "product",
+            }
+        )
+        self.product.categ_id.removal_strategy_id = self.least_package_strategy.id
+        self.stock_location = self.env["stock.location"].create(
+            {
+                "name": "stock_location",
+                "usage": "internal",
+            }
+        )
+
+    def _generate_data(self, packages_data):
+        move = self.env["stock.move"].create(
+            {
+                "name": "Test Least Package",
+                "product_id": self.product.id,
+                "product_uom": self.product.uom_id.id,
+                "location_id": self.ref("stock.stock_location_suppliers"),
+                "location_dest_id": self.stock_location.id,
+            }
+        )
+        move._action_confirm()
+
+        ml_vals_list = []
+        ml_common_vals = {
+            "move_id": move.id,
+            "product_id": self.product.id,
+            "product_uom_id": self.product.uom_id.id,
+            "location_id": self.ref("stock.stock_location_suppliers"),
+            "location_dest_id": self.stock_location.id,
+        }
+
+        packages = self.env["stock.quant.package"].create(
+            [{}] * sum(p[1] for p in packages_data if p[0])
+        )
+        for package_size, number_of_packages in packages_data:
+            if not package_size:
+                ml_vals_list.append(
+                    dict(
+                        **ml_common_vals,
+                        **{
+                            "product_uom_qty": number_of_packages,
+                        },
+                    )
+                )
+                continue
+            for _dummy in range(number_of_packages):
+                package = packages[0]
+                packages = packages[1:]
+                ml_vals_list.append(
+                    dict(
+                        **ml_common_vals,
+                        **{
+                            "product_uom_qty": package_size,
+                            "result_package_id": package.id,
+                        },
+                    )
+                )
+        self.env["stock.move.line"].create(ml_vals_list)
+        move._set_quantities_to_reservation()
+        move._action_done()
+
+    def test_least_package_removal_strategy_priority_to_package(self):
+        """
+        Tests the least package removal strategy in a use case where only one package
+        needs to be selected.
+        It should only return the quantity of a single size 1000 package.
+        """
+        packages_data = [
+            (False, 2000),
+            (5, 10),
+            (50, 10),
+            (1000, 2),
+        ]
+        self._generate_data(packages_data)
+
+        # Out 1000 should selecte a package with 1000 units inside
+        move = self.env["stock.move"].create(
+            {
+                "name": "Test Least Package",
+                "product_id": self.product.id,
+                "product_uom": self.product.uom_id.id,
+                "location_id": self.stock_location.id,
+                "location_dest_id": self.ref("stock.stock_location_customers"),
+                "product_uom_qty": 1000,
+            }
+        )
+        move._action_confirm()
+        move._action_assign()
+        self.assertEqual(len(move.move_line_ids), 1, "Only one pack could be use")
+        self.assertTrue(
+            move.move_line_ids.package_id,
+            "A package should be selected, priority to package even if there is enough"
+            " quantity without package",
+        )
+
+    def test_least_package_removal_strategy_simple_usecase(self):
+        """
+        Tests the least package removal strategy in a simple "typical" use case.
+        It should return a minimal exact matching for the requested quantity.
+        """
+        packages_data = [
+            (5, 10),
+            (50, 10),
+            (1000, 2),
+        ]
+        self._generate_data(packages_data)
+
+        # Out 1000 should select a package with 1000 units inside
+        move = self.env["stock.move"].create(
+            {
+                "name": "Test Least Package",
+                "product_id": self.product.id,
+                "product_uom": self.product.uom_id.id,
+                "location_id": self.stock_location.id,
+                "location_dest_id": self.ref("stock.stock_location_customers"),
+                "product_uom_qty": 1280,
+            }
+        )
+        move._action_confirm()
+        move._action_assign()
+        self.assertEqual(len(move.move_line_ids), 12)
+        self.assertRecordValues(
+            move.move_line_ids,
+            [{"product_uom_qty": 1000}]
+            + [{"product_uom_qty": 50}] * 5
+            + [{"product_uom_qty": 5}] * 6,
+        )
+
+    # FIXME
+    # def test_least_package_removal_strategy_not_possible(self):
+    #     """
+    #     Tests the least package removal strategy in the case where an exact matching
+    #     of packages is not possible for the requested amount.
+    #     It should return the best leaf from the A* search.
+    #     """
+    #     packages_data = [
+    #         (False, 2),
+    #         (5, 2),
+    #         (10, 5),
+    #     ]
+    #     self._generate_data(packages_data)
+    #
+    #     move = self.env['stock.move'].create({
+    #         'name': 'Test Least Package',
+    #         'product_id': self.product.id,
+    #         'product_uom': self.product.uom_id.id,
+    #         'location_id': self.stock_location.id,
+    #         'location_dest_id': self.ref('stock.stock_location_customers'),
+    #         'product_uom_qty': 13,
+    #     })
+    #     move._action_confirm()
+    #     move._action_assign()
+    #     self.assertEqual(len(move.move_line_ids), 2)
+    #     self.assertRecordValues(
+    #         move.move_line_ids,
+    #         [{'product_uom_qty': 10}] + [{'product_uom_qty': 3}]
+    #     )
+    #     # Make sure it selects the smallest possible package as best leaf.
+    #     self.assertEqual(
+    #         move.move_line_ids[1].package_id.quant_ids.quantity,
+    #         5
+    #     )
+
+    # FIXME
+    # def test_least_package_removal_strategy_not_enough(self):
+    #     """
+    #     Tests the least package removal strategy in the case where not enough quantity
+    #     is available to fill the requested amount.
+    #     It should just return all the quantities in the domain.
+    #     """
+    #     packages_data = [
+    #         (False, 2),
+    #         (5, 2),
+    #         (10, 5),
+    #     ]
+    #     self._generate_data(packages_data)
+    #
+    #     move = self.env['stock.move'].create({
+    #         'name': 'Test Least Package',
+    #         'product_id': self.product.id,
+    #         'product_uom': self.product.uom_id.id,
+    #         'location_id': self.stock_location.id,
+    #         'location_dest_id': self.ref('stock.stock_location_customers'),
+    #         'product_uom_qty': 90,
+    #     })
+    #     move._action_confirm()
+    #     move._action_assign()
+    #     self.assertEqual(len(move.move_line_ids), 8)
+    #     self.assertRecordValues(
+    #         move.move_line_ids,
+    #         [{'product_uom_qty': 2}] +
+    #         [{'product_uom_qty': 10}] * 5 +
+    #         [{'product_uom_qty': 5}] * 2
+    #     )
+
+    def test_clean_quant_after_package_move(self):
+        """
+        A product is at WH/Stock in a package PK. We deliver PK. The user should
+        not find any quant at WH/Stock with PK anymore.
+        """
+        package = self.env["stock.quant.package"].create({})
+        self.env["stock.quant"]._update_available_quantity(
+            self.product, self.stock_location, 1.0, package_id=package
+        )
+
+        move = self.env["stock.move"].create(
+            {
+                "name": "OUT 1 product",
+                "product_id": self.product.id,
+                "product_uom_qty": 1,
+                "product_uom": self.product.uom_id.id,
+                "location_id": self.stock_location.id,
+                "location_dest_id": self.ref("stock.stock_location_customers"),
+            }
+        )
+        move._action_confirm()
+        move._action_assign()
+        move.move_line_ids.write(
+            {
+                "result_package_id": package.id,
+                "product_uom_qty": 1,
+            }
+        )
+        move._set_quantities_to_reservation()
+        move._action_done()
+
+        self.assertFalse(
+            self.env["stock.quant"].search_count(
+                [
+                    ("product_id", "=", self.product.id),
+                    ("package_id", "=", package.id),
+                    ("location_id", "=", self.stock_location.id),
+                ]
+            )
+        )

--- a/backport_stock_removal_least_packages/tests/test_upstream.py
+++ b/backport_stock_removal_least_packages/tests/test_upstream.py
@@ -1,0 +1,6 @@
+from odoo.addons.stock.tests.test_quant import StockQuant
+
+
+# XXX: ensure that we've not broken anything upstream
+class TestUpstream(StockQuant):
+    pass

--- a/stock_barcode_putaway_rules/README.rst
+++ b/stock_barcode_putaway_rules/README.rst
@@ -1,0 +1,32 @@
+============================
+stock_barcode_putaway_rules
+============================
+
+Add a button to the barcode app that allows users to manually trigger putaway
+rule evaluation on a picking's move lines.
+
+- Adds a **Show 'Apply Putaway Rules' in Barcode** boolean on the picking type
+  form, controlling whether the button appears.
+- When the feature is enabled, an **Update Storage Location** button is shown
+  in the barcode app for pickings of that type.
+- Clicking the button calls ``_apply_putaway_strategy`` on the picking's move
+  lines, re-evaluating putaway rules and updating destination locations
+  accordingly.
+
+Usage
+=====
+
+Enabling the Feature
+--------------------
+
+1. Navigate to the picking type form (Inventory > Configuration > Operation
+   Types).
+2. Tick the **Show 'Apply Putaway Rules' in Barcode** checkbox.
+
+Using the Button
+----------------
+
+1. Open a picking of the enabled type in the barcode app.
+2. Click the **Update Storage Location** button in the control bar.
+3. The putaway rules are evaluated against the current move lines and
+   destination locations are updated.

--- a/stock_barcode_putaway_rules/__init__.py
+++ b/stock_barcode_putaway_rules/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/stock_barcode_putaway_rules/__manifest__.py
+++ b/stock_barcode_putaway_rules/__manifest__.py
@@ -17,5 +17,5 @@
     "data": [
         "views/stock_picking_type.xml",
     ],
-    "license": "LGPL-3",
+    "license": "Other proprietary",
 }

--- a/stock_barcode_putaway_rules/__manifest__.py
+++ b/stock_barcode_putaway_rules/__manifest__.py
@@ -1,0 +1,21 @@
+{
+    "name": "stock_barcode_putaway_rules",
+    "summary": "Add a button on the barcode app to evaluate putaway rules",
+    "author": "Glo Networks",
+    "website": "https://github.com/GlodoUK/odoo-addons",
+    "category": "Uncategorized",
+    "version": "15.0.1.0.0",
+    "depends": ["stock_barcode"],
+    "assets": {
+        "web.assets_backend": [
+            "stock_barcode_putaway_rules/static/src/**/*.js",
+        ],
+        "web.assets_qweb": [
+            "stock_barcode_putaway_rules/static/src/**/*.xml",
+        ],
+    },
+    "data": [
+        "views/stock_picking_type.xml",
+    ],
+    "license": "LGPL-3",
+}

--- a/stock_barcode_putaway_rules/models/__init__.py
+++ b/stock_barcode_putaway_rules/models/__init__.py
@@ -1,0 +1,2 @@
+from . import stock_picking
+from . import stock_picking_type

--- a/stock_barcode_putaway_rules/models/stock_picking.py
+++ b/stock_barcode_putaway_rules/models/stock_picking.py
@@ -1,0 +1,19 @@
+from odoo import fields, models
+
+
+class StockPicking(models.Model):
+    _inherit = "stock.picking"
+
+    show_stock_barcode_putaway_rules = fields.Boolean(
+        related="picking_type_id.show_stock_barcode_putaway_rules"
+    )
+
+    def apply_putaway_strategy(self):
+        self.ensure_one()
+        if self.show_stock_barcode_putaway_rules:
+            self.move_line_ids._apply_putaway_strategy()
+
+    def _get_fields_stock_barcode(self):
+        res = super()._get_fields_stock_barcode()
+        res.extend(["show_stock_barcode_putaway_rules"])
+        return res

--- a/stock_barcode_putaway_rules/models/stock_picking_type.py
+++ b/stock_barcode_putaway_rules/models/stock_picking_type.py
@@ -1,0 +1,9 @@
+from odoo import fields, models
+
+
+class StockPickingType(models.Model):
+    _inherit = "stock.picking.type"
+
+    show_stock_barcode_putaway_rules = fields.Boolean(
+        default=False, string="Show 'Apply Putaway Rules' in Barcode"
+    )

--- a/stock_barcode_putaway_rules/pyproject.toml
+++ b/stock_barcode_putaway_rules/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["whool"]
+build-backend = "whool.buildapi"

--- a/stock_barcode_putaway_rules/static/src/components/main.esm.js
+++ b/stock_barcode_putaway_rules/static/src/components/main.esm.js
@@ -1,0 +1,17 @@
+/** @odoo-module **/
+
+import MainComponent from "@stock_barcode/components/main";
+import {patch} from "web.utils";
+
+patch(MainComponent.prototype, "stock_barcode_putaway_rules", {
+    get showStockBarcodePutawayRules() {
+        console.log(this.env.model.record);
+        return (
+            this.env.model.record &&
+            this.env.model.record.show_stock_barcode_putaway_rules
+        );
+    },
+    async applyStockBarcodePutawayRules() {
+        await this.env.model._applyPutawayRules();
+    },
+});

--- a/stock_barcode_putaway_rules/static/src/components/main.xml
+++ b/stock_barcode_putaway_rules/static/src/components/main.xml
@@ -1,0 +1,12 @@
+<?xml version='1.0' encoding='utf-8' ?>
+<templates id="template" xml:space="preserve">
+    <t t-inherit="stock_barcode.MainComponent" t-inherit-mode="extension" owl="1">
+        <xpath expr="//div[hasclass('o_barcode_control')]" position="inside">
+            <button
+                class="btn btn-secondary text-uppercase stock_barcode_putaway_rules"
+                t-if="showStockBarcodePutawayRules"
+                t-on-click="applyStockBarcodePutawayRules"
+            >Update Storage Location</button>
+        </xpath>
+    </t>
+</templates>

--- a/stock_barcode_putaway_rules/static/src/models/barcode_picking_model.esm.js
+++ b/stock_barcode_putaway_rules/static/src/models/barcode_picking_model.esm.js
@@ -1,0 +1,14 @@
+/** @odoo-module **/
+
+import BarcodePickingModel from "@stock_barcode/models/barcode_picking_model";
+import {patch} from "web.utils";
+
+patch(BarcodePickingModel.prototype, "stock_barcode_putaway_rules", {
+    async _applyPutawayRules() {
+        await this.save();
+        await this.orm.call(this.params.model, "apply_putaway_strategy", [
+            [this.params.id],
+        ]);
+        this.trigger("refresh");
+    },
+});

--- a/stock_barcode_putaway_rules/views/stock_picking_type.xml
+++ b/stock_barcode_putaway_rules/views/stock_picking_type.xml
@@ -1,0 +1,14 @@
+<?xml version='1.0' encoding='utf-8' ?>
+<odoo>
+    <record id="view_picking_type_form" model="ir.ui.view">
+        <field name="name">view_picking_type_form</field>
+        <field name="model">stock.picking.type</field>
+        <field name="inherit_id" ref="stock.view_picking_type_form" />
+        <field name="priority">75</field>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='show_reserved']" position="after">
+                <field name="show_stock_barcode_putaway_rules" />
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/stock_location_freeze/README.rst
+++ b/stock_location_freeze/README.rst
@@ -1,0 +1,90 @@
+=====================
+stock_location_freeze
+=====================
+
+Freeze a stock location to prevent any further stock movements, reservations, or
+putaway operations until the freeze is released.
+
+- Freezing a parent location (e.g. WH/Stock) automatically prevents operations
+  on all of its sub-locations.
+- Freezing a sub-location does not affect its parent or sibling locations.
+- The freeze is enforced at the quant level: both ``_update_available_quantity``
+  and ``_update_reserved_quantity`` are blocked for frozen locations.
+- The ``_gather`` method filters out quants in frozen locations during
+  reservation (via the ``stock_location_freeze_gather`` context key).
+- Frozen locations are excluded from putaway rule evaluation.
+
+For developers and integrations that need to bypass the freeze programmatically:
+
+- ``stock_location_freeze_skip``: Set to ``True`` to bypass all freeze checks
+  (useful for inventory adjustments or corrections on frozen locations).
+
+Usage
+=====
+
+Freezing a Location
+-------------------
+
+1. Navigate to a stock location form (Inventory > Configuration > Warehouses >
+   Locations, or any location form).
+2. Click the **Freeze** button in the header.
+3. Select a freeze reason and click **Freeze** to confirm.
+
+If there is reserved stock in the location or its sub-locations, a warning will
+be displayed before you confirm.
+
+Once frozen:
+
+- No stock can be moved into or out of the location.
+- No reservations can be made against the location.
+- Putaway rules will not consider the location as a valid destination.
+- All sub-locations are also affected by the freeze.
+
+Unfreezing a Location
+---------------------
+
+1. Navigate to the frozen location form.
+2. Click the **Unfreeze** button in the header.
+
+The freeze information (who froze it, when, and why) is preserved after
+unfreezing for audit purposes. The unfreeze user and date are also recorded.
+
+Freeze Information
+------------------
+
+The following fields are displayed on the location form when relevant:
+
+- **Is Frozen?** -- Whether this specific location is frozen.
+- **Is Directly or Parent Frozen?** -- Whether this location is frozen
+  either directly or because a parent location is frozen.
+- **Frozen by Ancestor** -- Whether this location is only frozen because a
+  parent location is frozen (not directly frozen itself).
+- **Freeze Reason** -- The reason selected when the location was frozen.
+- **Frozen By** -- The user who froze the location.
+- **Freeze Date** -- When the location was frozen.
+- **Unfrozen By** -- The user who last unfroze the location.
+- **Unfreeze Date** -- When the location was last unfrozen.
+
+Why use this module vs OCA stock_location_lock
+==============================================
+
+The OCA `stock_location_lock` module also provides location locking
+functionality, but with an important difference in philosophy:
+
+- **OCA stock_location_lock** requires all stock to be removed from a location
+  before it can be locked. This is designed as a permanent or semi-permanent
+  state change and is unsuitable when you need to freeze a location in-place.
+
+- **This module (stock_location_freeze)** allows you to freeze a location
+  even when stock is still present. This makes it suitable for:
+
+  - **Temporary holds**: Quickly freeze a location for a short period without
+    needing to move stock out first.
+  - **Cycle counts and audits**: Freeze a location while counting or auditing
+    its contents, preventing any movements that would invalidate the count.
+  - **Incident response**: Immediately freeze a location when a discrepancy or
+    quality issue is detected, preserving the current state for investigation.
+
+In summary, use this module when you need to freeze a location in-situ with
+stock still present. Use OCA's module if you want to prevent stock from ever
+entering an empty location.

--- a/stock_location_freeze/__init__.py
+++ b/stock_location_freeze/__init__.py
@@ -1,0 +1,2 @@
+from . import models
+from . import wizards

--- a/stock_location_freeze/__manifest__.py
+++ b/stock_location_freeze/__manifest__.py
@@ -1,0 +1,15 @@
+{
+    "name": "stock_location_freeze",
+    "summary": "Prevent further movements of stock in a given location",
+    "author": "Glo Networks",
+    "website": "https://github.com/GlodoUK/odoo-addons",
+    "category": "Uncategorized",
+    "version": "15.0.1.0.2",
+    "depends": ["stock"],
+    "data": [
+        "security/ir.model.access.csv",
+        "wizards/freeze_views.xml",
+        "views/stock_location.xml",
+    ],
+    "license": "LGPL-3",
+}

--- a/stock_location_freeze/models/__init__.py
+++ b/stock_location_freeze/models/__init__.py
@@ -1,0 +1,3 @@
+from . import stock_location_freeze_reason
+from . import stock_quant
+from . import stock_location

--- a/stock_location_freeze/models/stock_location.py
+++ b/stock_location_freeze/models/stock_location.py
@@ -1,0 +1,89 @@
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError
+
+
+class StockLocation(models.Model):
+    _inherit = "stock.location"
+
+    frozen = fields.Boolean(default=False, string="Is Frozen?", readonly=True)
+    frozen_parent_path = fields.Boolean(
+        compute="_compute_frozen_parent_path",
+        store=True,
+        recursive=True,
+        string="Is Directly or Parent Frozen?",
+    )
+    frozen_by_ancestor = fields.Boolean(
+        compute="_compute_frozen_by_ancestor", store=False
+    )
+    freeze_reason_id = fields.Many2one("stock.location.freeze.reason", readonly=True)
+    freeze_uid = fields.Many2one("res.users", readonly=True, string="Frozen By")
+    freeze_date = fields.Datetime(readonly=True)
+    unfreeze_uid = fields.Many2one("res.users", readonly=True, string="Unfrozen By")
+    unfreeze_date = fields.Datetime(readonly=True)
+
+    @api.depends("name", "location_id.frozen_parent_path", "frozen", "parent_path")
+    def _compute_frozen_parent_path(self):
+        for location in self:
+            location.frozen_parent_path = (
+                location.frozen or location.location_id.frozen_parent_path
+            )
+
+    @api.depends("frozen_parent_path", "frozen")
+    def _compute_frozen_by_ancestor(self):
+        for location in self:
+            location.frozen_by_ancestor = (
+                not location.frozen and location.frozen_parent_path
+            )
+
+    def _ensure_not_frozen(self):
+        if self.env.context.get("stock_location_freeze_skip", False):
+            return
+
+        for record in self:
+            if record.frozen_parent_path:
+                origin_id = self.env["stock.location"].search(
+                    [("location_id", "parent_of", record.id), ("frozen", "=", True)],
+                    order="parent_path asc",
+                    limit=1,
+                )
+
+                raise UserError(
+                    _(
+                        "Location '%(location)s' is frozen. "
+                        "Please check the configuration at '%(origin)s'."
+                    )
+                    % {
+                        "location": record.display_name,
+                        "origin": origin_id.display_name,
+                    }
+                )
+
+    def _check_can_be_used(self, product, quantity=0, package=None, location_qty=0):
+        self.ensure_one()
+        # XXX: if the location is frozen then it's not valid for putaway rules at this
+        # time
+        if self.frozen_parent_path and not self.env.context.get(
+            "stock_location_freeze_skip", False
+        ):
+            return False
+        return super()._check_can_be_used(
+            product, quantity=quantity, package=package, location_qty=location_qty
+        )
+
+    def action_freeze(self):
+        self.ensure_one()
+        action = self.env["ir.actions.actions"]._for_xml_id(
+            "stock_location_freeze.action_stock_location_freeze"
+        )
+        action["context"] = {"default_location_id": self.id}
+        return action
+
+    def action_unfreeze(self):
+        self.ensure_one()
+        self.write(
+            {
+                "frozen": False,
+                "unfreeze_uid": self.env.uid,
+                "unfreeze_date": fields.Datetime.now(),
+            }
+        )

--- a/stock_location_freeze/models/stock_location_freeze_reason.py
+++ b/stock_location_freeze/models/stock_location_freeze_reason.py
@@ -1,0 +1,9 @@
+from odoo import fields, models
+
+
+class StockLocationFreezeReason(models.Model):
+    _name = "stock.location.freeze.reason"
+    _description = "Stock Location Freeze Reason"
+
+    name = fields.Char(required=True)
+    active = fields.Boolean(default=True)

--- a/stock_location_freeze/models/stock_quant.py
+++ b/stock_location_freeze/models/stock_quant.py
@@ -1,0 +1,72 @@
+from odoo import api, models
+
+
+class StockQuant(models.Model):
+    _inherit = "stock.quant"
+
+    @api.model
+    def _update_available_quantity(
+        self,
+        product_id,
+        location_id,
+        quantity,
+        lot_id=None,
+        package_id=None,
+        owner_id=None,
+        in_date=None,
+    ):
+        location_id.with_context(
+            stock_location_freeze_skip=self.env.context.get(
+                "stock_location_freeze_skip"
+            )
+        )._ensure_not_frozen()
+        return super()._update_available_quantity(
+            product_id, location_id, quantity, lot_id, package_id, owner_id, in_date
+        )
+
+    @api.model
+    def _update_reserved_quantity(
+        self,
+        product_id,
+        location_id,
+        quantity,
+        lot_id=None,
+        package_id=None,
+        owner_id=None,
+        strict=False,
+    ):
+        location_id.with_context(
+            stock_location_freeze_skip=self.env.context.get(
+                "stock_location_freeze_skip"
+            )
+        )._ensure_not_frozen()
+        return super(
+            StockQuant, self.with_context(stock_location_freeze_gather=True)
+        )._update_reserved_quantity(
+            product_id, location_id, quantity, lot_id, package_id, owner_id, strict
+        )
+
+    def _gather(
+        self,
+        product_id,
+        location_id,
+        lot_id=None,
+        package_id=None,
+        owner_id=None,
+        strict=False,
+    ):
+        res = super()._gather(
+            product_id,
+            location_id,
+            lot_id=lot_id,
+            package_id=package_id,
+            owner_id=owner_id,
+            strict=strict,
+        )
+
+        if self.env.context.get(
+            "stock_location_freeze_gather", False
+        ) and not self.env.context.get("stock_location_freeze_skip", False):
+            res = res.filtered(lambda x: not x.location_id.frozen_parent_path)
+
+        return res

--- a/stock_location_freeze/pyproject.toml
+++ b/stock_location_freeze/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["whool"]
+build-backend = "whool.buildapi"

--- a/stock_location_freeze/security/ir.model.access.csv
+++ b/stock_location_freeze/security/ir.model.access.csv
@@ -1,0 +1,4 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_stock_location_freeze_reason_user,stock.location.freeze.reason.user,model_stock_location_freeze_reason,stock.group_stock_user,1,0,0,0
+access_stock_location_freeze_reason_manager,stock.location.freeze.reason.manager,model_stock_location_freeze_reason,stock.group_stock_manager,1,1,1,1
+access_stock_location_freeze_user,stock.location.freeze.user,model_stock_location_freeze,stock.group_stock_user,1,1,1,0

--- a/stock_location_freeze/tests/__init__.py
+++ b/stock_location_freeze/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_freeze

--- a/stock_location_freeze/tests/test_freeze.py
+++ b/stock_location_freeze/tests/test_freeze.py
@@ -1,0 +1,388 @@
+from odoo.exceptions import UserError
+from odoo.tests.common import TransactionCase
+
+
+class TestStockLocationFreeze(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.stock_location = cls.env.ref("stock.stock_location_stock")
+        cls.supplier_location = cls.env.ref("stock.stock_location_suppliers")
+        cls.customer_location = cls.env.ref("stock.stock_location_customers")
+        cls.uom_unit = cls.env.ref("uom.product_uom_unit")
+
+        cls.stock_location.frozen = False
+
+        cls.product = cls.env["product.product"].create(
+            {
+                "name": "Test Product",
+                "type": "product",
+            }
+        )
+
+        # Create sub-locations for testing
+        cls.sublocation_a = cls.env["stock.location"].create(
+            {
+                "name": "Test Sublocation A",
+                "location_id": cls.stock_location.id,
+                "usage": "internal",
+            }
+        )
+        cls.sublocation_b = cls.env["stock.location"].create(
+            {
+                "name": "Test Sublocation B",
+                "location_id": cls.stock_location.id,
+                "usage": "internal",
+            }
+        )
+        # Create a nested sub-location under sublocation_a
+        cls.nested_sublocation = cls.env["stock.location"].create(
+            {
+                "name": "Nested Sublocation",
+                "location_id": cls.sublocation_a.id,
+                "usage": "internal",
+            }
+        )
+
+    def _create_quant(self, product, location, qty):
+        """Helper to create a quant with stock in a location."""
+        self.env["stock.quant"].create(
+            {
+                "product_id": product.id,
+                "location_id": location.id,
+                "quantity": qty,
+            }
+        )
+
+    def test_freeze_parent_blocks_reservations_and_movements(self):
+        """
+        Test that freezing WH/Stock prevents reservations and movements
+        in WH/Stock and all sub-locations.
+        """
+        # Add stock to various locations before freezing
+        self._create_quant(self.product, self.stock_location, 10.0)
+        self._create_quant(self.product, self.sublocation_a, 10.0)
+        self._create_quant(self.product, self.sublocation_b, 10.0)
+        self._create_quant(self.product, self.nested_sublocation, 10.0)
+
+        # Freeze WH/Stock
+        self.stock_location.frozen = True
+
+        # Verify frozen_parent_path is computed correctly
+        self.assertTrue(self.stock_location.frozen_parent_path)
+        self.assertTrue(self.sublocation_a.frozen_parent_path)
+        self.assertTrue(self.sublocation_b.frozen_parent_path)
+        self.assertTrue(self.nested_sublocation.frozen_parent_path)
+
+        # Test: Cannot update available quantity in WH/Stock (move stock in)
+        with self.assertRaises(UserError):
+            self.env["stock.quant"]._update_available_quantity(
+                self.product, self.stock_location, 5.0
+            )
+
+        # Test: Cannot update available quantity in sublocation_a
+        with self.assertRaises(UserError):
+            self.env["stock.quant"]._update_available_quantity(
+                self.product, self.sublocation_a, 5.0
+            )
+
+        # Test: Cannot update available quantity in nested_sublocation
+        with self.assertRaises(UserError):
+            self.env["stock.quant"]._update_available_quantity(
+                self.product, self.nested_sublocation, 5.0
+            )
+
+        # Test: Cannot reserve stock in WH/Stock
+        with self.assertRaises(UserError):
+            self.env["stock.quant"]._update_reserved_quantity(
+                self.product, self.stock_location, 5.0
+            )
+
+        # Test: Cannot reserve stock in sublocation_a
+        with self.assertRaises(UserError):
+            self.env["stock.quant"]._update_reserved_quantity(
+                self.product, self.sublocation_a, 5.0
+            )
+
+        # Test: Cannot reserve stock in sublocation_b
+        with self.assertRaises(UserError):
+            self.env["stock.quant"]._update_reserved_quantity(
+                self.product, self.sublocation_b, 5.0
+            )
+
+        # Test: Cannot reserve stock in nested_sublocation
+        with self.assertRaises(UserError):
+            self.env["stock.quant"]._update_reserved_quantity(
+                self.product, self.nested_sublocation, 5.0
+            )
+
+        # Unfreeze WH/Stock and verify operations are now allowed
+        self.stock_location.frozen = False
+
+        self.assertFalse(self.stock_location.frozen_parent_path)
+        self.assertFalse(self.sublocation_a.frozen_parent_path)
+
+        # Should now be able to update quantities
+        self.env["stock.quant"]._update_available_quantity(
+            self.product, self.stock_location, 5.0
+        )
+        self.env["stock.quant"]._update_reserved_quantity(
+            self.product, self.sublocation_a, 5.0
+        )
+
+    def test_freeze_sublocation_allows_parent_operations(self):
+        """
+        Test that freezing only a sub-location allows reservations and movements
+        against the parent location, but blocks them for the frozen sub-location.
+        """
+        # Add stock to various locations before freezing
+        self._create_quant(self.product, self.stock_location, 10.0)
+        self._create_quant(self.product, self.sublocation_a, 10.0)
+        self._create_quant(self.product, self.sublocation_b, 10.0)
+        self._create_quant(self.product, self.nested_sublocation, 10.0)
+
+        # Freeze only sublocation_a (not the parent WH/Stock)
+        self.stock_location.frozen = False
+        self.sublocation_a.frozen = True
+
+        # Verify frozen_parent_path is computed correctly
+        self.assertFalse(self.stock_location.frozen_parent_path)
+        self.assertTrue(self.sublocation_a.frozen_parent_path)
+        self.assertFalse(self.sublocation_b.frozen_parent_path)
+        self.assertTrue(self.nested_sublocation.frozen_parent_path)
+
+        # Test: CAN update available quantity in WH/Stock (parent is not frozen)
+        self.env["stock.quant"]._update_available_quantity(
+            self.product, self.stock_location, 5.0
+        )
+
+        # Test: CAN update available quantity in sublocation_b (sibling, not frozen)
+        self.env["stock.quant"]._update_available_quantity(
+            self.product, self.sublocation_b, 5.0
+        )
+
+        # Test: CAN reserve stock in WH/Stock
+        self.env["stock.quant"]._update_reserved_quantity(
+            self.product, self.stock_location, 5.0
+        )
+
+        # Test: CAN reserve stock in sublocation_b
+        self.env["stock.quant"]._update_reserved_quantity(
+            self.product, self.sublocation_b, 5.0
+        )
+
+        # Test: CANNOT update available quantity in sublocation_a (frozen)
+        with self.assertRaises(UserError):
+            self.env["stock.quant"]._update_available_quantity(
+                self.product, self.sublocation_a, 5.0
+            )
+
+        # Test: CANNOT update available quantity in nested_sublocation (parent frozen)
+        with self.assertRaises(UserError):
+            self.env["stock.quant"]._update_available_quantity(
+                self.product, self.nested_sublocation, 5.0
+            )
+
+        # Test: CANNOT reserve stock in sublocation_a (frozen)
+        with self.assertRaises(UserError):
+            self.env["stock.quant"]._update_reserved_quantity(
+                self.product, self.sublocation_a, 5.0
+            )
+
+        # Test: CANNOT reserve stock in nested_sublocation (parent frozen)
+        with self.assertRaises(UserError):
+            self.env["stock.quant"]._update_reserved_quantity(
+                self.product, self.nested_sublocation, 5.0
+            )
+
+        # Unfreeze sublocation_a and verify operations are now allowed
+        self.sublocation_a.frozen = False
+
+        self.assertFalse(self.sublocation_a.frozen_parent_path)
+        self.assertFalse(self.nested_sublocation.frozen_parent_path)
+
+        # Should now be able to update quantities in previously frozen locations
+        self.env["stock.quant"]._update_available_quantity(
+            self.product, self.sublocation_a, 5.0
+        )
+        self.env["stock.quant"]._update_reserved_quantity(
+            self.product, self.nested_sublocation, 5.0
+        )
+
+    def test_skip_context_bypasses_freeze(self):
+        """
+        Test that when stock_location_freeze_skip context is True,
+        operations are allowed even on frozen locations.
+        """
+        # Add stock to locations
+        self._create_quant(self.product, self.stock_location, 10.0)
+        self._create_quant(self.product, self.sublocation_a, 10.0)
+
+        # Freeze the locations
+        self.stock_location.frozen = True
+
+        # Verify the locations are frozen
+        self.assertTrue(self.stock_location.frozen_parent_path)
+        self.assertTrue(self.sublocation_a.frozen_parent_path)
+
+        # Without skip context, operations should fail
+        with self.assertRaises(UserError):
+            self.env["stock.quant"]._update_available_quantity(
+                self.product, self.stock_location, 5.0
+            )
+
+        # With skip context, operations should succeed
+        self.env["stock.quant"].with_context(
+            stock_location_freeze_skip=True
+        )._update_available_quantity(self.product, self.stock_location, 5.0)
+
+        self.env["stock.quant"].with_context(
+            stock_location_freeze_skip=True
+        )._update_available_quantity(self.product, self.sublocation_a, 5.0)
+
+        self.env["stock.quant"].with_context(
+            stock_location_freeze_skip=True
+        )._update_reserved_quantity(self.product, self.stock_location, 5.0)
+
+        self.env["stock.quant"].with_context(
+            stock_location_freeze_skip=True
+        )._update_reserved_quantity(self.product, self.sublocation_a, 5.0)
+
+    def test_action_assign_skips_frozen_sublocations(self):
+        """
+        Test that _action_assign on a stock.move does not reserve stock
+        from frozen sub-locations, but does reserve after unfreezing.
+        """
+        # Only put stock in sublocation_a (not in WH/Stock itself)
+        self._create_quant(self.product, self.sublocation_a, 5.0)
+
+        # Create a stock move from WH/Stock to Customers
+        move = self.env["stock.move"].create(
+            {
+                "name": "Test Move",
+                "product_id": self.product.id,
+                "product_uom": self.uom_unit.id,
+                "product_uom_qty": 5.0,
+                "location_id": self.stock_location.id,
+                "location_dest_id": self.customer_location.id,
+            }
+        )
+        move._action_confirm()
+
+        # Freeze sublocation_a
+        self.sublocation_a.frozen = True
+        self.assertTrue(self.sublocation_a.frozen_parent_path)
+
+        # Try to assign - should not reserve anything since stock is in frozen location
+        move._action_assign()
+        self.assertEqual(
+            move.reserved_availability,
+            0.0,
+            "Should not reserve stock from frozen sublocation",
+        )
+
+        # Unfreeze sublocation_a
+        self.stock_location.frozen = False
+        self.sublocation_a.frozen = False
+        self.assertFalse(self.sublocation_a.frozen_parent_path)
+
+        # Try to assign again - should now reserve the stock
+        move._action_assign()
+        self.assertEqual(
+            move.reserved_availability,
+            5.0,
+            "Should reserve stock after unfreezing sublocation",
+        )
+
+    def test_gather_only_filters_with_context(self):
+        """
+        Test that _gather only filters out frozen locations when the
+        stock_location_freeze_gather context is True.
+        """
+        # Create stock in sublocation_a
+        self._create_quant(self.product, self.sublocation_a, 10.0)
+
+        # Without context, _gather returns quants even when unfrozen
+        quants = self.env["stock.quant"]._gather(self.product, self.sublocation_a)
+        self.assertEqual(len(quants), 1)
+        self.assertEqual(quants.quantity, 10.0)
+
+        # Freeze sublocation_a
+        self.sublocation_a.frozen = True
+        self.assertTrue(self.sublocation_a.frozen_parent_path)
+
+        # Without context, _gather still returns quants (no filtering)
+        quants = self.env["stock.quant"]._gather(self.product, self.sublocation_a)
+        self.assertEqual(
+            len(quants), 1, "_gather without context should return all quants"
+        )
+
+        # With stock_location_freeze_gather context, _gather filters out frozen
+        # locations
+        quants = (
+            self.env["stock.quant"]
+            .with_context(stock_location_freeze_gather=True)
+            ._gather(self.product, self.sublocation_a)
+        )
+        self.assertEqual(
+            len(quants), 0, "_gather with context should filter frozen locations"
+        )
+
+    def test_check_can_be_used_returns_false_for_frozen(self):
+        """
+        Test that _check_can_be_used returns False for frozen locations,
+        preventing them from being used in putaway rules.
+        """
+        # Create stock in sublocation_a
+        self._create_quant(self.product, self.sublocation_a, 10.0)
+
+        self.stock_location.frozen = False
+        self.sublocation_a.frozen = False
+        self.assertFalse(self.sublocation_a.frozen_parent_path)
+
+        # Unfrozen location should return True
+        self.assertTrue(self.sublocation_a._check_can_be_used(self.product, quantity=1))
+
+        # Freeze the location
+        self.sublocation_a.frozen = True
+
+        # Frozen location should return False
+        self.assertFalse(
+            self.sublocation_a._check_can_be_used(self.product, quantity=1)
+        )
+
+        # With skip context, should return True again
+        self.assertTrue(
+            self.sublocation_a.with_context(
+                stock_location_freeze_skip=True
+            )._check_can_be_used(self.product)
+        )
+
+    def test_gather_skip_context_bypasses_filter(self):
+        """
+        Test that stock_location_freeze_skip bypasses _gather filtering
+        even when stock_location_freeze_gather is True.
+        """
+        self._create_quant(self.product, self.sublocation_a, 10.0)
+
+        # Freeze the location
+        self.sublocation_a.frozen = True
+
+        # With only gather context, should filter out frozen locations
+        quants = (
+            self.env["stock.quant"]
+            .with_context(stock_location_freeze_gather=True)
+            ._gather(self.product, self.sublocation_a)
+        )
+        self.assertEqual(len(quants), 0)
+
+        # With both gather and skip context, should NOT filter
+        quants = (
+            self.env["stock.quant"]
+            .with_context(
+                stock_location_freeze_gather=True,
+                stock_location_freeze_skip=True,
+            )
+            ._gather(self.product, self.sublocation_a)
+        )
+        self.assertEqual(len(quants), 1)

--- a/stock_location_freeze/views/stock_location.xml
+++ b/stock_location_freeze/views/stock_location.xml
@@ -1,0 +1,56 @@
+<?xml version='1.0' encoding='utf-8' ?>
+<odoo>
+    <record id="view_location_form" model="ir.ui.view">
+        <field name="name">view_location_form</field>
+        <field name="model">stock.location</field>
+        <field name="priority">75</field>
+        <field name="inherit_id" ref="stock.view_location_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//sheet" position="before">
+                <header>
+                    <button
+                        name="action_freeze"
+                        type="object"
+                        icon="fa-lock"
+                        attrs="{'invisible': [('frozen', '=', True)]}"
+                        string="Freeze"
+                    />
+                    <button
+                        name="action_unfreeze"
+                        type="object"
+                        icon="fa-unlock"
+                        attrs="{'invisible': [('frozen', '=', False)]}"
+                        string="Unfreeze"
+                    />
+                </header>
+            </xpath>
+            <xpath expr="//group[@name='additional_info']" position="after">
+                <group string="Freeze Information" name="freeze_info">
+                    <field name="frozen" />
+                    <field name="frozen_parent_path" />
+                    <field name="frozen_by_ancestor" />
+                    <field
+                        name="freeze_reason_id"
+                        attrs="{'invisible': [('frozen', '=', False)]}"
+                    />
+                    <field
+                        name="freeze_uid"
+                        attrs="{'invisible': [('frozen', '=', False)]}"
+                    />
+                    <field
+                        name="freeze_date"
+                        attrs="{'invisible': [('frozen', '=', False)]}"
+                    />
+                    <field
+                        name="unfreeze_uid"
+                        attrs="{'invisible': [('frozen', '=', True)]}"
+                    />
+                    <field
+                        name="unfreeze_date"
+                        attrs="{'invisible': [('frozen', '=', True)]}"
+                    />
+                </group>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/stock_location_freeze/wizards/__init__.py
+++ b/stock_location_freeze/wizards/__init__.py
@@ -1,0 +1,1 @@
+from . import freeze

--- a/stock_location_freeze/wizards/freeze.py
+++ b/stock_location_freeze/wizards/freeze.py
@@ -1,0 +1,51 @@
+from odoo import _, api, fields, models
+
+
+class StockLocationFreeze(models.TransientModel):
+    _name = "stock.location.freeze"
+    _description = "Freeze Stock Location"
+
+    location_id = fields.Many2one("stock.location", required=True)
+    freeze_reason_id = fields.Many2one("stock.location.freeze.reason", required=True)
+    warning_message = fields.Text(compute="_compute_warning_message")
+
+    @api.depends("location_id")
+    def _compute_warning_message(self):
+        for wizard in self:
+            if not wizard.location_id:
+                wizard.warning_message = False
+                continue
+
+            reserved_quants = self.env["stock.quant"].search_count(
+                [
+                    ("location_id", "child_of", wizard.location_id.id),
+                    ("reserved_quantity", ">", 0),
+                ]
+            )
+
+            if reserved_quants > 0:
+                wizard.warning_message = _(
+                    "Warning: There is reserved stock in this location "
+                    "(or its sub-locations). Freezing this location will prevent "
+                    "these items from being picked or unreserved until the freeze "
+                    "is removed."
+                )
+            else:
+                wizard.warning_message = False
+
+    def action_freeze(self):
+        self.ensure_one()
+        if self.location_id.frozen:
+            return {"type": "ir.actions.act_window_close"}
+
+        self.location_id.write(
+            {
+                "frozen": True,
+                "freeze_reason_id": self.freeze_reason_id.id,
+                "freeze_uid": self.env.uid,
+                "freeze_date": fields.Datetime.now(),
+                "unfreeze_uid": False,
+                "unfreeze_date": False,
+            }
+        )
+        return {"type": "ir.actions.act_window_close"}

--- a/stock_location_freeze/wizards/freeze_views.xml
+++ b/stock_location_freeze/wizards/freeze_views.xml
@@ -1,0 +1,37 @@
+<?xml version='1.0' encoding='utf-8' ?>
+<odoo>
+    <record id="stock_location_freeze_form" model="ir.ui.view">
+        <field name="name">stock.location.freeze.form</field>
+        <field name="model">stock.location.freeze</field>
+        <field name="arch" type="xml">
+            <form string="Freeze Location">
+                <div
+                    class="alert alert-warning"
+                    role="alert"
+                    attrs="{'invisible': [('warning_message', '=', False)]}"
+                >
+                    <field name="warning_message" nolabel="1" />
+                </div>
+                <group>
+                    <field name="location_id" readonly="1" />
+                    <field name="freeze_reason_id" options="{'no_create': False}" />
+                </group>
+                <footer>
+                    <button
+                        name="action_freeze"
+                        string="Freeze"
+                        type="object"
+                        class="btn-primary"
+                    />
+                    <button string="Cancel" class="btn-secondary" special="cancel" />
+                </footer>
+            </form>
+        </field>
+    </record>
+    <record id="action_stock_location_freeze" model="ir.actions.act_window">
+        <field name="name">Freeze Location</field>
+        <field name="res_model">stock.location.freeze</field>
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+    </record>
+</odoo>


### PR DESCRIPTION
This is a collection of modules currently written for and being tested by a 15.0 customer.

- stock_location_freeze: Freeze a location in place, preventing further reservations, unreservations or stock movements
- stock_barcode_putaway_rules: Provide a button in the barcoding app on specific operation types to manually trigger putaway rule suggestions
- backport_stock_removal_least_packages: Backport of the "least packages" removal strategy from Odoo 17.0 to 15.0

Fixes GH190289

**Dependencies:**
- N/A

**ARL (Associated Risk Level):**
- [ ] Low
- [ ] Medium
- [x] High

**Type of change:**
- [x] Forwardport / Backport
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

