### PR TITLE
[19.0][REF] Changes to cpq module suite

### DIFF
--- a/cpq/static/src/components/dialog/dialog.xml
+++ b/cpq/static/src/components/dialog/dialog.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8' ?>
 <templates xml:space="preserve">
 
-    <t t-name="cpq.ConfigureDialog" owl="1">
+    <t t-name="cpq.ConfigureDialog">
         <Dialog size="props.size or 'lg'" title="title">
             <div class="row g-3">
                 <div class="col-auto">
@@ -21,7 +21,7 @@
                                 t-foreach="Object.entries(state.errors)"
                                 t-as="entry"
                                 t-key="entry[0]"
-                                t-esc="entry[1]"
+                                t-out="entry[1]"
                             />
                         </ul>
                     </div>
@@ -29,7 +29,7 @@
                     <div
                         t-if="state.productTmpl &amp;&amp; state.productTmpl.description_sale"
                         class="mb-3"
-                        t-esc="state.productTmpl.description_sale"
+                        t-out="state.productTmpl.description_sale"
                     />
 
                     <ProductTmplAttrib

--- a/cpq/static/src/components/dialog/product_tmpl_attrib.xml
+++ b/cpq/static/src/components/dialog/product_tmpl_attrib.xml
@@ -1,14 +1,10 @@
 <?xml version='1.0' encoding='utf-8' ?>
 <templates xml:space="preserve">
 
-    <t t-name="cpq.ProductTmplAttrib" owl="1">
+    <t t-name="cpq.ProductTmplAttrib">
         <div class="mb-3">
             <div class="mb-2">
-                <label
-                    t-if="props.attribute.ptav_ids.length &gt; 1 or hasCustomPTAV"
-                    class="form-label fw-bold"
-                    t-esc="props.attribute.name"
-                />
+                <label class="form-label fw-bold" t-out="props.attribute.name" />
                 <t t-call="{{ getPTAVTemplate() }}" />
             </div>
 
@@ -19,7 +15,7 @@
                     t-key="ptav.id"
                     class="mb-2"
                 >
-                    <strong t-esc="ptav.name" class="form-label d-block" />
+                    <strong t-out="ptav.name" class="form-label d-block" />
                     <input
                         t-if="ptav.cpq_custom_type !== 'many2one'"
                         class="form-control o_input"
@@ -38,7 +34,7 @@
         </div>
     </t>
 
-    <t t-name="cpq.ProductTmplAttribSelect" owl="1">
+    <t t-name="cpq.ProductTmplAttribSelect">
         <select
             class="form-select"
             t-on-change="onSelect"
@@ -53,12 +49,12 @@
                 t-att-value="ptav.id"
                 t-att-selected="isSelected(ptav.id)"
                 t-att-class="{ 'css_not_available': ptav.excluded }"
-                t-esc="ptav.name"
+                t-out="ptav.name"
             />
         </select>
     </t>
 
-    <t t-name="cpq.ProductTmplAttribRadio" owl="1">
+    <t t-name="cpq.ProductTmplAttribRadio">
         <div class="d-flex flex-wrap gap-3">
             <div
                 t-foreach="props.attribute.ptav_ids"
@@ -81,13 +77,13 @@
                     t-att-class="{ 'css_not_available': ptav.excluded }"
                     t-att-for="'ptav-' + ptav.id"
                 >
-                    <span t-esc="ptav.name" />
+                    <span t-out="ptav.name" />
                 </label>
             </div>
         </div>
     </t>
 
-    <t t-name="cpq.ProductTmplAttribColor" owl="1">
+    <t t-name="cpq.ProductTmplAttribColor">
         <ul class="list-inline mb-0">
             <li
                 t-foreach="props.attribute.ptav_ids"

--- a/cpq_banding/static/src/components/cpq_product_tmpl_attr.xml
+++ b/cpq_banding/static/src/components/cpq_product_tmpl_attr.xml
@@ -20,7 +20,7 @@
                     t-key="i[0]"
                     t-att-value="i[0]"
                     t-att-selected="props.selected[ptav.id] == i[0]"
-                    t-esc="i[1]"
+                    t-out="i[1]"
                 />
             </select>
         </xpath>

--- a/cpq_mrp/__manifest__.py
+++ b/cpq_mrp/__manifest__.py
@@ -14,6 +14,7 @@
         "views/dynamic_bom_line.xml",
         "views/stock_picking.xml",
         "views/stock_move_line.xml",
+        "views/mrp_production.xml",
         "views/product.xml",
         "views/menu.xml",
     ],

--- a/cpq_mrp/models/dynamic_bom.py
+++ b/cpq_mrp/models/dynamic_bom.py
@@ -19,11 +19,8 @@ class DynamicBom(models.Model):
         index=True,
     )
     type = fields.Selection(
-        [
-            ("phantom", "Kit"),
-            ("normal", "Manufacture"),
-        ],
-        default="phantom",
+        [("normal", "Manufacture"), ("phantom", "Kit")],
+        default="normal",
         required=True,
         index=True,
     )
@@ -100,16 +97,6 @@ class DynamicBom(models.Model):
         if not all(self.mapped("product_tmpl_id.cpq_ok")):
             raise ValidationError(
                 self.env._("Product Template must be enabled as configurable")
-            )
-
-    @api.constrains("type", "picking_type_id")
-    def _ensure_manufacture_has_picking_type_id(self):
-        if not self.env.user.has_group("stock.group_adv_location"):
-            return
-
-        if self.filtered(lambda b: b.type == "normal" and not b.picking_type_id):
-            raise ValidationError(
-                self.env._("Manufactured dynamic BoMs must have an operation type set")
             )
 
     @api.onchange("product_tmpl_id")

--- a/cpq_mrp/models/mrp_production.py
+++ b/cpq_mrp/models/mrp_production.py
@@ -4,11 +4,39 @@ from odoo import Command, api, fields, models
 class MrpProduction(models.Model):
     _inherit = "mrp.production"
 
+    cpq_ok = fields.Boolean(related="product_id.cpq_ok")
+
     cpq_dynamic_bom_id = fields.Many2one(
         "cpq.dynamic.bom",
+        "Configurable Bill of Materials",
         context={"active_test": False},
         index=True,
+        compute="_compute_cpq_dynamic_bom_id",
+        store=True,
+        precompute=True,
+        domain="[('product_tmpl_id', '=', product_tmpl_id), ('type', '=', 'normal')]",
     )
+
+    @api.depends("product_id")
+    def _compute_cpq_dynamic_bom_id(self):
+        for production in self:
+            if not production.product_id or not production.product_id.cpq_ok:
+                production.cpq_dynamic_bom_id = False
+                continue
+
+            if (
+                production.cpq_dynamic_bom_id
+                and production.cpq_dynamic_bom_id.product_tmpl_id
+                == production.product_id.product_tmpl_id
+            ):
+                continue
+
+            dyn_bom = (
+                production.product_id.product_tmpl_id.cpq_dynamic_bom_ids.filtered(
+                    lambda b: b.type == "normal"
+                )[:1]
+            )
+            production.cpq_dynamic_bom_id = dyn_bom or False
 
     def _compute_move_raw_ids(self):
         cpq_productions = self.filtered(lambda p: p.product_id.cpq_ok)
@@ -25,11 +53,7 @@ class MrpProduction(models.Model):
 
         for production in cpq_productions:
             if production.state == "draft":
-                dyn_bom = (
-                    production.product_id.product_tmpl_id.cpq_dynamic_bom_ids.filtered(
-                        lambda b: b.type == "normal"
-                    )[:1]
-                )
+                dyn_bom = production.cpq_dynamic_bom_id
 
                 if (
                     not dyn_bom
@@ -38,9 +62,6 @@ class MrpProduction(models.Model):
                 ):
                     production.move_raw_ids = [Command.clear()]
                     continue
-
-                if production.cpq_dynamic_bom_id != dyn_bom:
-                    production.cpq_dynamic_bom_id = dyn_bom
 
                 bom_lines = dyn_bom.explode(
                     production.product_id, production.product_qty
@@ -84,6 +105,13 @@ class MrpProduction(models.Model):
 
                 production.move_raw_ids = list_move_raw
 
+        return res
+
+    def _compute_show_generate_bom(self):
+        res = super()._compute_show_generate_bom()
+        for production in self:
+            if production.product_id.cpq_ok:
+                production.show_generate_bom = False
         return res
 
     # fmt off

--- a/cpq_mrp/models/product_template.py
+++ b/cpq_mrp/models/product_template.py
@@ -75,13 +75,22 @@ class ProductTemplate(models.Model):
             record.cpq_dynamic_bom_count = len(record.cpq_dynamic_bom_ids)
 
     def action_view_cpq_dynamic_bom(self):
-        return {
+        self.ensure_one()
+
+        action = {
             "type": "ir.actions.act_window",
             "name": self.env._("Configurable Products Bill of Materials"),
             "res_model": "cpq.dynamic.bom",
             "view_mode": "form",
-            "res_id": self.cpq_dynamic_bom_ids.id,
+            "context": {
+                **self.env.context,
+                "default_product_tmpl_id": self.id,
+                "default_product_uom_id": self.uom_id.id,
+            },
         }
+        if self.cpq_dynamic_bom_ids:
+            action["res_id"] = self.cpq_dynamic_bom_ids[:1].id
+        return action
 
     def write(self, vals):
         if not self.env.context.get("cpq_mrp_skip_auto_archive", False):

--- a/cpq_mrp/models/stock_rule.py
+++ b/cpq_mrp/models/stock_rule.py
@@ -89,6 +89,7 @@ class StockRule(models.Model):
         return move_values
 
     # fmt: off
+    # ruff: noqa: E501
     @api.model
     def _run_manufacture(self, procurements):
         procurements_without_dynamic_bom = []
@@ -96,7 +97,7 @@ class StockRule(models.Model):
 
         for procurement, rule in procurements:
             product_id = procurement.product_id.with_company(procurement.company_id)
-            if not (product_id.cpq_ok and product_id.cpq_dynamic_bom_ids.type == "normal"):  # noqa: E501
+            if not (product_id.cpq_ok and product_id.cpq_dynamic_bom_ids.type == "normal"):
                 procurements_without_dynamic_bom.append((procurement, rule))
                 continue
 
@@ -109,12 +110,14 @@ class StockRule(models.Model):
                 *procurement, self.env["mrp.bom"]
             )
             picking_type = dyn_bom_id.picking_type_id or rule.picking_type_id
-            production_values.update({
+            update_vals = {
                 "consumption": dyn_bom_id.consumption,
-                "picking_type_id": picking_type.id,
-                "location_src_id": picking_type.default_location_src_id.id,
                 "cpq_dynamic_bom_id": dyn_bom_id.id,
-            })
+            }
+            if picking_type:
+                update_vals["picking_type_id"] = picking_type.id
+                update_vals["location_src_id"] = picking_type.default_location_src_id.id
+            production_values.update(update_vals)
 
             cpq_productions_by_company[procurement.company_id.id]["values"].append(production_values)
             cpq_productions_by_company[procurement.company_id.id]["procurements"].append(procurement)

--- a/cpq_mrp/views/dynamic_bom.xml
+++ b/cpq_mrp/views/dynamic_bom.xml
@@ -31,16 +31,19 @@
                             <field name="code" />
                             <field name="type" widget="radio" />
                             <p
-                                class="oe_grey oe_edit_only"
+                                colspan="2"
+                                class="opacity-50 oe_edit_only"
                                 invisible="type != 'phantom'"
                             >
                                 <ul>
-                                    A BoM of type kit is used to split the product into its components.
+                                    A BoM of type Kit is not produced with a manufacturing order.<br
+                                />
+                                    Instead, it is used to decompose a BoM into its components when:
                                     <li>
-                                        At the creation of a Manufacturing Order.
+                                        it is added as a component in a manufacturing order
                                     </li>
                                     <li>
-                                        At the creation of a Stock Transfer.
+                                        it is moved via a transfer, such as a receipt or a delivery order for instance.
                                     </li>
                                 </ul>
                             </p>
@@ -202,7 +205,7 @@
     </record>
 
     <record id="action_cpq_dynamic_bom_act_window" model="ir.actions.act_window">
-        <field name="name">Configurable Products Bill of Materials</field>
+        <field name="name">Configurable Bills of Materials</field>
         <field name="res_model">cpq.dynamic.bom</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">

--- a/cpq_mrp/views/mrp_production.xml
+++ b/cpq_mrp/views/mrp_production.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="mrp_production_form_view" model="ir.ui.view">
+        <field name="name">cpq_mrp.mrp_production_form_view</field>
+        <field name="model">mrp.production</field>
+        <field name="inherit_id" ref="mrp.mrp_production_form_view" />
+        <field name="arch" type="xml">
+            <field name="product_id" position="after">
+                <field name="cpq_ok" invisible="1" />
+            </field>
+            <label for="bom_id" name="bom_label" position="attributes">
+                <attribute name="invisible">cpq_ok</attribute>
+            </label>
+            <div name="bom_div" position="attributes">
+                <attribute name="invisible">cpq_ok</attribute>
+            </div>
+            <div name="bom_div" position="after">
+                <label for="cpq_dynamic_bom_id" invisible="not cpq_ok" />
+                <div class="o_row" invisible="not cpq_ok">
+                    <field
+                        name="cpq_dynamic_bom_id"
+                        context="{'default_product_tmpl_id': product_tmpl_id}"
+                        invisible="state != 'draft' and not cpq_dynamic_bom_id"
+                        readonly="state != 'draft'"
+                    />
+                </div>
+            </div>
+        </field>
+    </record>
+</odoo>

--- a/cpq_mrp/views/product.xml
+++ b/cpq_mrp/views/product.xml
@@ -3,18 +3,15 @@
     <record id="product_template_form_view_bom_button" model="ir.ui.view">
         <field name="name">product.template</field>
         <field name="model">product.template</field>
-        <field
-            name="inherit_id"
-            ref="stock.product_template_form_view_procurement_button"
-        />
+        <field name="inherit_id" ref="mrp.product_template_form_view_bom_button" />
         <field name="priority">99</field>
         <field name="arch" type="xml">
-            <xpath expr="//button[@name='action_open_product_lot']" position="after">
+            <xpath expr="//button[@name='%(mrp.template_open_bom)d']" position="after">
                 <button
                     class="oe_stat_button"
                     name="action_view_cpq_dynamic_bom"
                     type="object"
-                    invisible="not cpq_ok or cpq_dynamic_bom_count == 0"
+                    invisible="not cpq_ok"
                     icon="fa-flask"
                     groups="mrp.group_mrp_user"
                 >

--- a/helpdesk_portal_new_ticket/views/template_helpdesk_ticket_new.xml
+++ b/helpdesk_portal_new_ticket/views/template_helpdesk_ticket_new.xml
@@ -29,7 +29,7 @@
                             <label
                                 t-attf-for="team_id_{{ team_id.id }}"
                                 class="form-check-label"
-                                t-esc="team_id.display_name"
+                                t-out="team_id.display_name"
                             />
                         </div>
                     </t>


### PR DESCRIPTION
Change `t-esc` to `t-out`

Remove owl="1"

When a product attribute has only one possible value or does not have a custom PTAV, still show the label

Change DynamicBom `type` field definition to match MrpBom `type` field definition

Refactor Picking Type on DynamicBom to function the same way as Picking Type on MrpBom. The field can be left blank but is used in `_run_manufacture`

Make `cpq_dynamic_bom_id` on MrpProduction computed, just like `bom_id`

Hide Generate BoM button on the production form view if the product is CPQ

Make the dynamic BoM smart button visible on the product template form view for a CPQ product, even if a dynamic BoM doesn't exist yet

Formatting fixes for phantom dynamic BoMs

**Dependencies:**
- N/A

**ARL (Associated Risk Level):**
- [X] Low
- [ ] Medium
- [ ] High

**Type of change:**
- [ ] Forwardport / Backport
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

