### PR TITLE
[REF] Mute logger in test_recover_from_keyerror

### DIFF
--- a/res_partner_bank_display_format/models/res_partner_bank.py
+++ b/res_partner_bank_display_format/models/res_partner_bank.py
@@ -3,7 +3,7 @@ import re
 
 from odoo import api, fields, models
 
-_logger = logging.getLogger(__file__)
+_logger = logging.getLogger(__name__)
 
 
 class ResPartnerBank(models.Model):

--- a/res_partner_bank_display_format/tests/test_custom_display_name_format.py
+++ b/res_partner_bank_display_format/tests/test_custom_display_name_format.py
@@ -1,4 +1,5 @@
 from odoo.tests import TransactionCase, tagged
+from odoo.tools import mute_logger
 
 
 @tagged("post_install", "-at_install")
@@ -44,6 +45,7 @@ class TestCustomDisplayNameFormat(TransactionCase):
         self.assertEqual("TESTY TEST Test123", self.res_partner_bank_id.display_name)
         self.assertFalse(self.res_partner_bank_id.custom_display_name_format_warning)
 
+    @mute_logger("odoo.addons.res_partner_bank_display_format.models.res_partner_bank")
     def test_recover_from_keyerror(self):
         self.res_partner_bank_id.acc_number = False
         self.res_partner_bank_id.custom_display_name_format = (


### PR DESCRIPTION
Fixes `Run CI` from failing on `19.0`

**Dependencies:**
- N/A

**ARL (Associated Risk Level):**
- [X] Low
- [ ] Medium
- [ ] High

**Type of change:**
- [ ] Forwardport / Backport
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

