### PR TITLE
[GH200498][FEAT] res_partner_update module

### DIFF
--- a/res_partner_update/README.rst
+++ b/res_partner_update/README.rst
@@ -1,0 +1,9 @@
+==================
+res_partner_update
+==================
+
+A minimal implementation of updates on ``res.partner`` based on ``project.update``
+
+A smart button on the partner form links to the partner's ``project.update`` records
+
+Access is controlled via ``group_res_partner_update_user`` and ``group_res_partner_update_manager``

--- a/res_partner_update/__init__.py
+++ b/res_partner_update/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/res_partner_update/__manifest__.py
+++ b/res_partner_update/__manifest__.py
@@ -1,0 +1,14 @@
+{
+    "name": "res_partner_update",
+    "version": "19.0.1.0.0",
+    "author": "Glo Networks",
+    "website": "https://github.com/GlodoUK/odoo-addons",
+    "depends": ["base"],
+    "data": [
+        "security/res_groups_data.xml",
+        "security/ir.model.access.csv",
+        "views/res_partner_views.xml",
+        "views/res_partner_update_views.xml",
+    ],
+    "license": "LGPL-3",
+}

--- a/res_partner_update/models/__init__.py
+++ b/res_partner_update/models/__init__.py
@@ -1,0 +1,2 @@
+from . import res_partner
+from . import res_partner_update

--- a/res_partner_update/models/res_partner.py
+++ b/res_partner_update/models/res_partner.py
@@ -1,0 +1,39 @@
+from odoo import fields, models
+
+
+class ResPartner(models.Model):
+    _inherit = "res.partner"
+
+    partner_update_ids = fields.One2many(
+        "res.partner.update",
+        "partner_id",
+    )
+
+    partner_update_count = fields.Integer(compute="_compute_partner_update_count")
+
+    def _compute_partner_update_count(self):
+        if not self.ids:
+            self.partner_update_count = 0
+            return
+
+        res_partner_update_data = self.env["res.partner.update"]._read_group(
+            [("partner_id", "in", self.ids)],
+            ["partner_id"],
+            ["__count"],
+        )
+
+        count_data = {partner.id: count for partner, count in res_partner_update_data}
+
+        for partner in self:
+            partner.partner_update_count = count_data.get(partner.id, 0)
+
+    def action_view_res_partner_update(self):
+        self.ensure_one()
+
+        return {
+            "type": "ir.actions.act_window",
+            "name": self.env._("Partner Updates"),
+            "res_model": "res.partner.update",
+            "view_mode": "list,form",
+            "context": {"default_partner_id": self.id},
+        }

--- a/res_partner_update/models/res_partner_update.py
+++ b/res_partner_update/models/res_partner_update.py
@@ -1,0 +1,28 @@
+from odoo import fields, models
+
+
+class ResPartnerUpdate(models.Model):
+    _name = "res.partner.update"
+    _description = "Partner Update"
+    _order = "id desc"
+
+    name = fields.Char(
+        required=True,
+    )
+
+    date = fields.Date(
+        default=fields.Date.context_today,
+    )
+
+    description = fields.Html()
+
+    partner_id = fields.Many2one(
+        "res.partner",
+        required=True,
+    )
+
+    user_id = fields.Many2one(
+        "res.users",
+        default=lambda self: self.env.user,
+        required=True,
+    )

--- a/res_partner_update/pyproject.toml
+++ b/res_partner_update/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["whool"]
+build-backend = "whool.buildapi"

--- a/res_partner_update/security/ir.model.access.csv
+++ b/res_partner_update/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_res_partner_update_user,res.partner.update.user,model_res_partner_update,group_res_partner_update_user,1,0,0,0
+access_res_partner_update_manager,res.partner.update.manager,model_res_partner_update,group_res_partner_update_manager,1,1,1,1

--- a/res_partner_update/security/res_groups_data.xml
+++ b/res_partner_update/security/res_groups_data.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="group_res_partner_update_user" model="res.groups">
+        <field name="name">Partner Updates: User</field>
+        <field name="implied_ids" eval="[(4, ref('base.group_user'))]" />
+    </record>
+
+    <record id="group_res_partner_update_manager" model="res.groups">
+        <field name="name">Partner Updates: Manager</field>
+        <field name="implied_ids" eval="[(4, ref('group_res_partner_update_user'))]" />
+    </record>
+</odoo>

--- a/res_partner_update/views/res_partner_update_views.xml
+++ b/res_partner_update/views/res_partner_update_views.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="res_partner_update_view_form" model="ir.ui.view">
+        <field name="name">res.partner.update.form</field>
+        <field name="model">res.partner.update</field>
+        <field name="arch" type="xml">
+            <form>
+                <sheet>
+                    <div class="oe_title">
+                        <h1>
+                            <field name="name" placeholder="e.g. Monthly Review" />
+                        </h1>
+                    </div>
+                    <group>
+                        <group>
+                            <field name="partner_id" />
+                        </group>
+                        <group>
+                            <field name="user_id" readonly="1" />
+                            <field name="date" readonly="1" />
+                        </group>
+                    </group>
+                    <field name="description" placeholder="Description..." />
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="res_partner_update_view_list" model="ir.ui.view">
+        <field name="name">res.partner.update.list</field>
+        <field name="model">res.partner.update</field>
+        <field name="arch" type="xml">
+            <list>
+                <field name="name" />
+                <field name="partner_id" />
+                <field name="user_id" />
+                <field name="date" />
+            </list>
+        </field>
+    </record>
+
+    <record id="res_partner_update_view_search" model="ir.ui.view">
+        <field name="name">res.partner.update.search</field>
+        <field name="model">res.partner.update</field>
+        <field name="arch" type="xml">
+            <search>
+                <field name="name" />
+                <field name="partner_id" />
+
+                <filter
+                    name="filter_my_updates"
+                    string="My Updates"
+                    domain="[('user_id', '=', uid)]"
+                />
+
+                <group>
+                    <filter
+                        name="group_partner"
+                        string="Partner"
+                        context="{'group_by': 'partner_id'}"
+                    />
+                    <filter
+                        name="group_user"
+                        string="User"
+                        context="{'group_by': 'user_id'}"
+                    />
+                </group>
+            </search>
+        </field>
+    </record>
+
+    <record id="res_partner_update_action" model="ir.actions.act_window">
+        <field name="name">Partner Updates</field>
+        <field name="res_model">res.partner.update</field>
+        <field name="view_mode">list,form</field>
+    </record>
+</odoo>

--- a/res_partner_update/views/res_partner_views.xml
+++ b/res_partner_update/views/res_partner_views.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="view_partner_form" model="ir.ui.view">
+        <field name="name">res.partner.form</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.view_partner_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//div[@name='button_box']" position="inside">
+                <button
+                    name="action_view_res_partner_update"
+                    type="object"
+                    class="oe_stat_button"
+                    icon="fa-comments"
+                    groups="res_partner_update.group_res_partner_update_user"
+                >
+                    <field
+                        name="partner_update_count"
+                        widget="statinfo"
+                        string="Updates"
+                    />
+                </button>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Fixes GH200498

A minimal implementation of updates on ``res.partner`` based on ``project.update``

A smart button on the partner form links to the partner's ``project.update`` records

Access is controlled via ``group_res_partner_update_user`` and ``group_res_partner_update_manager``

**Dependencies:**
- N/A

**ARL (Associated Risk Level):**
- [X] Low
- [ ] Medium
- [ ] High

**Type of change:**
- [ ] Forwardport / Backport
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

