### PR TITLE
[FIX] web.assets_backend_lazy instead of web.assets_backend

### DIFF
--- a/web_graph_bar_zerofill/__manifest__.py
+++ b/web_graph_bar_zerofill/__manifest__.py
@@ -5,7 +5,7 @@
     "website": "https://github.com/GlodoUK/odoo-addons",
     "depends": ["web"],
     "assets": {
-        "web.assets_backend": [
+        "web.assets_backend_lazy": [
             "web_graph_bar_zerofill/static/src/js/graph_model_patch.esm.js",
         ],
     },


### PR DESCRIPTION
Move to the correct Odoo bundle.

**Dependencies:**
- N/A

**ARL (Associated Risk Level):**
- [X] Low
- [ ] Medium
- [ ] High

**Type of change:**
- [ ] Forwardport / Backport
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

