### PR TITLE
[FEAT] Expiration date and expiration reason from remote

### DIFF
--- a/glodo_client/controllers/main.py
+++ b/glodo_client/controllers/main.py
@@ -124,6 +124,11 @@ class GlodoCloudClient(Controller):
                     ]
                 )
 
+                # Enterprise subscription metadata, when present.
+                ICP = env["ir.config_parameter"].sudo()
+                expiration_date = ICP.get_param("database.expiration_date")
+                expiration_reason = ICP.get_param("database.expiration_reason")
+
                 # Get installed modules
                 modules = env["ir.module.module"].search([("state", "=", "installed")])
                 module_list = [
@@ -137,6 +142,8 @@ class GlodoCloudClient(Controller):
                 db_info = {
                     "name": db_name,
                     "user_count": user_count,
+                    "expiration_date": expiration_date or None,
+                    "expiration_reason": expiration_reason or None,
                     "installed_modules": module_list,
                     "cloc": {},
                 }

--- a/glodo_server/models/glodo_action_log.py
+++ b/glodo_server/models/glodo_action_log.py
@@ -24,7 +24,6 @@ class GlodoActionLog(models.Model):
 
     instance_name = fields.Char(
         related="instance_id.name",
-        string="Instance Name",
         store=True,
     )
 
@@ -35,7 +34,6 @@ class GlodoActionLog(models.Model):
 
     remote_user_login = fields.Char(
         related="remote_user_id.login",
-        string="Remote User Login",
         store=True,
     )
 

--- a/glodo_server/models/glodo_instance.py
+++ b/glodo_server/models/glodo_instance.py
@@ -320,6 +320,8 @@ class GlodoInstance(models.Model):
 
             db_vals = {
                 "user_count": db_data.get("user_count", 0),
+                "expiration_date": db_data.get("expiration_date") or False,
+                "expiration_reason": db_data.get("expiration_reason") or False,
                 "installed_modules_json": json.dumps(
                     db_data.get("installed_modules", [])
                 ),

--- a/glodo_server/models/glodo_instance_database.py
+++ b/glodo_server/models/glodo_instance_database.py
@@ -9,10 +9,15 @@ import json
 import logging
 from collections import defaultdict
 
+from dateutil.relativedelta import relativedelta
+
 from odoo import api, fields, models
 from odoo.exceptions import UserError
+from odoo.fields import Domain
 
 _logger = logging.getLogger(__name__)
+
+EXPIRY_WARNING_DAYS = 30
 
 
 class GlodoInstanceDatabase(models.Model):
@@ -21,7 +26,6 @@ class GlodoInstanceDatabase(models.Model):
     _order = "instance_id, name"
 
     name = fields.Char(
-        string="Database Name",
         required=True,
         index=True,
     )
@@ -39,8 +43,8 @@ class GlodoInstanceDatabase(models.Model):
     )
 
     instance_name = fields.Char(
-        related="instance_id.name",
         string="Instance Name",
+        related="instance_id.name",
         store=True,
         readonly=True,
     )
@@ -50,8 +54,8 @@ class GlodoInstanceDatabase(models.Model):
     )
 
     instance_active = fields.Boolean(
-        related="instance_id.active",
         string="Instance Active",
+        related="instance_id.active",
     )
 
     remote_user_ids = fields.One2many(
@@ -76,6 +80,22 @@ class GlodoInstanceDatabase(models.Model):
         string="Internal User Count",
         readonly=True,
         help="Number of internal users reported by the remote",
+    )
+
+    expiration_date = fields.Datetime(
+        readonly=True,
+        help="Enterprise subscription expiration date reported by the remote",
+    )
+
+    expiration_reason = fields.Char(
+        readonly=True,
+        help="Enterprise subscription expiration reason reported by the remote",
+    )
+
+    expiration_state = fields.Selection(
+        [("success", "OK"), ("warning", "Expiring Soon"), ("danger", "Expired")],
+        compute="_compute_expiration_state",
+        search="_search_expiration_state",
     )
 
     installed_modules_json = fields.Text(
@@ -125,6 +145,56 @@ class GlodoInstanceDatabase(models.Model):
         for db in self:
             db.active_remote_user_count = count_data[db.id]["active"]
             db.inactive_remote_user_count = count_data[db.id]["inactive"]
+
+    @api.depends("expiration_date")
+    def _compute_expiration_state(self):
+        now = fields.Datetime.now()
+        warning_threshold = now + relativedelta(days=EXPIRY_WARNING_DAYS)
+        for db in self:
+            expiration_date = db.expiration_date
+            if not expiration_date:
+                db.expiration_state = "success"
+                continue
+            db.expiration_state = (
+                "danger"
+                if expiration_date <= now
+                else "warning"
+                if expiration_date <= warning_threshold
+                else "success"
+            )
+
+    # See _search_status on HelpdeskSlaStatus for a similar search method
+    @api.model
+    def _search_expiration_state(self, operator, value):
+        if operator != "in":
+            return NotImplemented
+        now = fields.Datetime.now()
+        warning_threshold = now + relativedelta(days=EXPIRY_WARNING_DAYS)
+        domains = []
+        if "success" in value:
+            domains.append(
+                [
+                    "|",
+                    ("expiration_date", "=", False),
+                    ("expiration_date", ">", warning_threshold),
+                ]
+            )
+        if "warning" in value:
+            domains.append(
+                [
+                    ("expiration_date", "!=", False),
+                    ("expiration_date", ">", now),
+                    ("expiration_date", "<=", warning_threshold),
+                ]
+            )
+        if "danger" in value:
+            domains.append(
+                [
+                    ("expiration_date", "!=", False),
+                    ("expiration_date", "<=", now),
+                ]
+            )
+        return Domain.OR(domains)
 
     @api.depends("installed_modules_json")
     def _compute_installed_modules_html(self):

--- a/glodo_server/models/glodo_remote_user.py
+++ b/glodo_server/models/glodo_remote_user.py
@@ -41,6 +41,7 @@ class GlodoRemoteUser(models.Model):
     )
 
     database_name = fields.Char(
+        string="Database Name",
         related="database_id.name",
         store=True,
     )
@@ -52,6 +53,7 @@ class GlodoRemoteUser(models.Model):
     )
 
     instance_name = fields.Char(
+        string="Instance Name",
         related="database_id.instance_name",
         store=True,
     )
@@ -75,7 +77,8 @@ class GlodoRemoteUser(models.Model):
     )
 
     _unique_database_remote_id = models.Constraint(
-        "UNIQUE(database_id, remote_id)", "Remote user ID must be unique per database."
+        "UNIQUE(database_id, remote_id)",
+        "Remote user ID must be unique per database.",
     )
 
     def action_become_user(self):

--- a/glodo_server/views/glodo_action_log_views.xml
+++ b/glodo_server/views/glodo_action_log_views.xml
@@ -5,7 +5,7 @@
         <field name="name">glodo.action.log.view.form</field>
         <field name="model">glodo.action.log</field>
         <field name="arch" type="xml">
-            <form string="Action Log" create="0" edit="0">
+            <form create="0" edit="0">
                 <sheet>
                     <group>
                         <group string="Action Details">

--- a/glodo_server/views/glodo_instance_database_views.xml
+++ b/glodo_server/views/glodo_instance_database_views.xml
@@ -4,7 +4,7 @@
         <field name="name">glodo.instance.database.view.form</field>
         <field name="model">glodo.instance.database</field>
         <field name="arch" type="xml">
-            <form string="Instance Database">
+            <form>
                 <header>
                     <button
                         name="action_sync_users"
@@ -43,6 +43,8 @@
                         </group>
                         <group string="Statistics">
                             <field name="user_count" />
+                            <field name="expiration_date" />
+                            <field name="expiration_reason" />
                             <field name="last_user_sync" />
                         </group>
                     </group>
@@ -112,9 +114,15 @@
         <field name="name">glodo.instance.database.view.list</field>
         <field name="model">glodo.instance.database</field>
         <field name="arch" type="xml">
-            <list>
+            <list
+                decoration-warning="expiration_state == 'warning'"
+                decoration-danger="expiration_state == 'danger'"
+            >
+                <field name="expiration_state" invisible="1" />
                 <field name="name" />
                 <field name="instance_name" />
+                <field name="expiration_date" optional="show" />
+                <field name="expiration_reason" optional="hide" />
                 <field name="active_remote_user_count" sum="Active Users" />
                 <field
                     name="inactive_remote_user_count"
@@ -133,6 +141,8 @@
             <search>
                 <field name="name" />
                 <field name="instance_id" />
+                <field name="expiration_date" />
+                <field name="expiration_reason" />
                 <filter
                     string="Active"
                     name="filter_active"
@@ -143,6 +153,23 @@
                     name="filter_archived"
                     domain="[('active', '=', False)]"
                 />
+                <separator />
+                <filter
+                    string="OK"
+                    name="filter_expiration_ok"
+                    domain="[('expiration_state', 'in', ['success'])]"
+                />
+                <filter
+                    string="Expiring Soon"
+                    name="filter_expiration_warning"
+                    domain="[('expiration_state', 'in', ['warning'])]"
+                />
+                <filter
+                    string="Expired"
+                    name="filter_expiration_danger"
+                    domain="[('expiration_state', 'in', ['danger'])]"
+                />
+                <separator />
                 <filter
                     string="Instance"
                     name="groupby_instance"

--- a/glodo_server/views/glodo_instance_views.xml
+++ b/glodo_server/views/glodo_instance_views.xml
@@ -5,7 +5,7 @@
         <field name="name">glodo.instance.view.form</field>
         <field name="model">glodo.instance</field>
         <field name="arch" type="xml">
-            <form string="Managed Instance">
+            <form>
                 <header>
                     <button
                         name="action_sync_info"
@@ -123,6 +123,7 @@
                             <field name="database_ids">
                                 <list string="Databases">
                                     <field name="name" />
+                                    <field name="expiration_date" optional="show" />
                                     <field name="active_remote_user_count" />
                                     <field
                                         name="inactive_remote_user_count"

--- a/glodo_server/views/glodo_remote_user_views.xml
+++ b/glodo_server/views/glodo_remote_user_views.xml
@@ -4,7 +4,7 @@
         <field name="name">glodo.remote.user.view.form</field>
         <field name="model">glodo.remote.user</field>
         <field name="arch" type="xml">
-            <form string="Remote User">
+            <form>
                 <header>
                     <button
                         name="action_become_user"

--- a/glodo_server/wizards/glodo_instance_info_wizard_views.xml
+++ b/glodo_server/wizards/glodo_instance_info_wizard_views.xml
@@ -4,7 +4,7 @@
         <field name="name">glodo.instance.info.wizard.view.form</field>
         <field name="model">glodo.instance.info.wizard</field>
         <field name="arch" type="xml">
-            <form string="Instance Information">
+            <form>
                 <group>
                     <field name="instance_id" readonly="1" />
                 </group>


### PR DESCRIPTION
Includes pre-commit fixes

Simplest implementation.

Find the expiration date and expiration reason from `glodo_client` side and set fields on the `glodo_server` side.

- [X] Computed field to show an expiration warning if the expiration date is close or passed. decoration-warning and decoration-danger on list view

**Dependencies:**
- N/A

**ARL (Associated Risk Level):**
- [X] Low
- [ ] Medium
- [ ] High

**Type of change:**
- [ ] Forwardport / Backport
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

