### PR TITLE
[19.0][ADD] stock_picking_archive

### DIFF
--- a/stock_picking_archive/README.rst
+++ b/stock_picking_archive/README.rst
@@ -1,0 +1,10 @@
+=====================
+stock_picking_archive
+=====================
+
+This is a technical module allowing you to archive `stock.picking` records.
+
+Similarly to the OCA module `sale_order_archive` this should not be done lightly.
+
+In an isolated stock-only sense this is fine. However, this module is potentially damaging when `sale_stock` is installed.
+

--- a/stock_picking_archive/__init__.py
+++ b/stock_picking_archive/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/stock_picking_archive/__manifest__.py
+++ b/stock_picking_archive/__manifest__.py
@@ -1,0 +1,13 @@
+{
+    "name": "stock_picking_archive",
+    "summary": "Allow stock.picking records to be archived",
+    "author": "Glo Networks",
+    "website": "https://github.com/GlodoUK/odoo-addons",
+    "category": "Uncategorized",
+    "version": "19.0.1.0.0",
+    "depends": ["stock"],
+    "data": [
+        "views/stock_picking.xml",
+    ],
+    "license": "LGPL-3",
+}

--- a/stock_picking_archive/models/__init__.py
+++ b/stock_picking_archive/models/__init__.py
@@ -1,0 +1,1 @@
+from . import stock_picking

--- a/stock_picking_archive/models/stock_picking.py
+++ b/stock_picking_archive/models/stock_picking.py
@@ -1,0 +1,20 @@
+from odoo import fields, models
+from odoo.exceptions import UserError
+
+
+class StockPicking(models.Model):
+    _inherit = "stock.picking"
+
+    active = fields.Boolean(default=True, index=True)
+
+    def action_archive(self):
+        unsafe = self.filtered(lambda x: x.state not in ("done", "cancel", "draft"))
+        if unsafe:
+            raise UserError(
+                self.env._(
+                    "There are %(count)d pickings not in a safe state to archive",
+                    count=len(unsafe),
+                )
+            )
+
+        return super().action_archive()

--- a/stock_picking_archive/pyproject.toml
+++ b/stock_picking_archive/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["whool"]
+build-backend = "whool.buildapi"

--- a/stock_picking_archive/tests/__init__.py
+++ b/stock_picking_archive/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_archive

--- a/stock_picking_archive/tests/test_archive.py
+++ b/stock_picking_archive/tests/test_archive.py
@@ -1,0 +1,57 @@
+from odoo.exceptions import UserError
+from odoo.tests import TransactionCase
+
+
+class TestArchive(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.product = cls.env["product.product"].create(
+            {
+                "name": "Definitely Not a Pedal Bin",
+                "type": "consu",
+            }
+        )
+        cls.partner = cls.env["res.partner"].create(
+            {
+                "name": "Test Partner",
+            }
+        )
+        cls.picking_type_out = cls.env.ref("stock.picking_type_out")
+        cls.stock_picking = cls.env["stock.picking"].create(
+            {
+                "partner_id": cls.partner.id,
+                "picking_type_id": cls.picking_type_out.id,
+                "location_id": cls.picking_type_out.default_location_src_id.id,
+                "location_dest_id": cls.picking_type_out.default_location_dest_id.id,
+            }
+        )
+        cls.env["stock.move"].create(
+            {
+                "product_id": cls.product.id,
+                "product_uom_qty": 10,
+                "product_uom": cls.product.uom_id.id,
+                "picking_id": cls.stock_picking.id,
+                "location_id": cls.picking_type_out.default_location_src_id.id,
+                "location_dest_id": cls.picking_type_out.default_location_dest_id.id,
+            }
+        )
+
+    def test_stock_picking_archive_toggle_active(self):
+        self.assertTrue(self.stock_picking.active)
+        self.stock_picking.action_archive()
+        self.assertFalse(self.stock_picking.active)
+        self.stock_picking.action_unarchive()
+        self.assertTrue(self.stock_picking.active)
+
+    def test_stock_picking_archive_toggle_active_locked(self):
+        self.assertTrue(self.stock_picking.active)
+        self.stock_picking.state = "confirmed"
+        with self.assertRaises(UserError):
+            self.stock_picking.action_archive()
+
+    def test_stock_picking_archive_cancelled_toggle_active(self):
+        self.assertTrue(self.stock_picking.active)
+        self.stock_picking.action_cancel()
+        self.stock_picking.action_archive()
+        self.assertFalse(self.stock_picking.active)

--- a/stock_picking_archive/views/stock_picking.xml
+++ b/stock_picking_archive/views/stock_picking.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <record id="vpicktree" model="ir.ui.view">
+        <field name="name">vpicktree</field>
+        <field name="model">stock.picking</field>
+        <field name="inherit_id" ref="stock.vpicktree" />
+        <field name="arch" type="xml">
+            <xpath expr="//list" position="inside">
+                <field name="active" column_invisible="true" />
+            </xpath>
+        </field>
+    </record>
+    <record id="view_picking_form" model="ir.ui.view">
+        <field name="name">view_picking_form</field>
+        <field name="model">stock.picking</field>
+        <field name="inherit_id" ref="stock.view_picking_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//form" position="inside">
+                <field name="active" invisible="true" />
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Adds the ability to archive `stock.picking` records in safe-ish circumstances only.

In an isolated stock-only sense this is fine. However, this module is potentially damaging when `sale_stock` is installed.

**Dependencies:**
- N/A

**ARL (Associated Risk Level):**
- [x] Low
- [ ] Medium
- [ ] High

**Type of change:**
- [ ] Forwardport / Backport
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

