### PR TITLE
[19.0][ADD] stock_picking_mandatory_packing

### DIFF
--- a/stock_picking_mandatory_packing/README.rst
+++ b/stock_picking_mandatory_packing/README.rst
@@ -1,0 +1,7 @@
+=======================
+stock_picking_mandatory
+=======================
+
+Adds a "Must be Packed" option to `stock.picking.type` (operation type) which is checked
+during `stock.picking::_sanity_check` to ensure that all lines are packaged.
+

--- a/stock_picking_mandatory_packing/__init__.py
+++ b/stock_picking_mandatory_packing/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/stock_picking_mandatory_packing/__manifest__.py
+++ b/stock_picking_mandatory_packing/__manifest__.py
@@ -1,0 +1,13 @@
+{
+    "name": "stock_picking_mandatory_packing",
+    "summary": "Ensure that a picking type must have all items packaged",
+    "author": "Glo Networks",
+    "website": "https://github.com/GlodoUK/odoo-addons",
+    "category": "Uncategorized",
+    "version": "19.0.1.0.0",
+    "depends": ["stock"],
+    "data": [
+        "views/stock_picking_type.xml",
+    ],
+    "license": "LGPL-3",
+}

--- a/stock_picking_mandatory_packing/models/__init__.py
+++ b/stock_picking_mandatory_packing/models/__init__.py
@@ -1,0 +1,2 @@
+from . import stock_picking
+from . import stock_picking_type

--- a/stock_picking_mandatory_packing/models/stock_picking.py
+++ b/stock_picking_mandatory_packing/models/stock_picking.py
@@ -1,0 +1,23 @@
+from odoo import models
+from odoo.exceptions import UserError
+
+
+class StockPicking(models.Model):
+    _inherit = "stock.picking"
+
+    def _sanity_check(self, separate_pickings=True):
+        res = super()._sanity_check(separate_pickings=separate_pickings)
+        for picking in self.filtered(lambda x: x.picking_type_id.must_be_packed):
+            move_lines_without_package = picking.move_line_ids.filtered(
+                lambda x: not x.result_package_id
+            )
+            if move_lines_without_package:
+                raise UserError(
+                    self.env._(
+                        "The following move lines have not been packaged: %(line)s",
+                        line=", ".join(
+                            move_lines_without_package.mapped("display_name")
+                        ),
+                    )
+                )
+        return res

--- a/stock_picking_mandatory_packing/models/stock_picking_type.py
+++ b/stock_picking_mandatory_packing/models/stock_picking_type.py
@@ -1,0 +1,24 @@
+from odoo import api, fields, models
+from odoo.exceptions import ValidationError
+
+VALID_TYPES = ["incoming", "outgoing", "internal"]
+
+
+class StockPickingType(models.Model):
+    _inherit = "stock.picking.type"
+
+    must_be_packed = fields.Boolean(default=False)
+
+    @api.constrains("must_be_packed", "code")
+    def _ensure_must_be_packed_is_safe(self):
+        invalid = self.filtered(
+            lambda x: x.code not in VALID_TYPES and x.must_be_packed
+        )
+        if invalid:
+            raise ValidationError(
+                self.env._(
+                    "'Must be packed' can only be set on one of the following types:"
+                    " %(types)s",
+                    types=", ".join(VALID_TYPES),
+                )
+            )

--- a/stock_picking_mandatory_packing/pyproject.toml
+++ b/stock_picking_mandatory_packing/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["whool"]
+build-backend = "whool.buildapi"

--- a/stock_picking_mandatory_packing/tests/__init__.py
+++ b/stock_picking_mandatory_packing/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_mandatory

--- a/stock_picking_mandatory_packing/tests/test_mandatory.py
+++ b/stock_picking_mandatory_packing/tests/test_mandatory.py
@@ -1,0 +1,104 @@
+from unittest.mock import patch
+
+from odoo.exceptions import UserError, ValidationError
+from odoo.tests import TransactionCase
+
+
+class TestMandatoryPacking(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.warehouse = cls.env.ref("stock.warehouse0")
+        cls.picking_type_out = cls.warehouse.out_type_id
+        cls.picking_type_in = cls.warehouse.in_type_id
+        cls.picking_type_int = cls.warehouse.int_type_id
+        cls.product = cls.env["product.product"].create(
+            {
+                "name": "Test Product",
+                "type": "consu",
+            }
+        )
+
+    def _make_picking(self, picking_type):
+        return self.env["stock.picking"].create(
+            {
+                "picking_type_id": picking_type.id,
+                "location_id": picking_type.default_location_src_id.id,
+                "location_dest_id": picking_type.default_location_dest_id.id,
+            }
+        )
+
+    def _add_move_line(self, picking, result_package=False):
+        self.env["stock.move.line"].create(
+            {
+                "picking_id": picking.id,
+                "product_id": self.product.id,
+                "product_uom_id": self.product.uom_id.id,
+                "qty_done": 1.0,
+                "location_id": picking.location_id.id,
+                "location_dest_id": picking.location_dest_id.id,
+                "result_package_id": result_package.id if result_package else False,
+            }
+        )
+
+    def test_constrains_allows_outgoing(self):
+        self.picking_type_out.must_be_packed = True
+
+    def test_constrains_allows_incoming(self):
+        self.picking_type_in.must_be_packed = True
+
+    def test_constrains_allows_internal(self):
+        self.picking_type_int.must_be_packed = True
+
+    def test_constrains_rejects_non_standard_code(self):
+        invalid_type = self.env["stock.picking.type"].search(
+            [("code", "not in", ["incoming", "outgoing", "internal"])], limit=1
+        )
+        if not invalid_type:
+            self.skipTest("No picking type with a non-standard code is installed")
+        with self.assertRaises(ValidationError):
+            invalid_type.must_be_packed = True
+
+    def _sanity_check(self, picking):
+        """Call _sanity_check with the parent implementation stubbed out so we
+        only exercise this module's logic in isolation."""
+        with patch(
+            "odoo.addons.stock.models.stock_picking.StockPicking._sanity_check",
+            return_value=None,
+        ):
+            picking._sanity_check()
+
+    def test_no_error_when_must_be_packed_false_and_no_package(self):
+        self.picking_type_out.must_be_packed = False
+        picking = self._make_picking(self.picking_type_out)
+        self._add_move_line(picking)
+        self._sanity_check(picking)  # must not raise
+
+    def test_no_error_when_must_be_packed_true_and_all_lines_packaged(self):
+        self.picking_type_out.must_be_packed = True
+        picking = self._make_picking(self.picking_type_out)
+        package = self.env["stock.package"].create({})
+        self._add_move_line(picking, result_package=package)
+        self._sanity_check(picking)  # must not raise
+
+    def test_error_when_must_be_packed_true_and_lines_without_package(self):
+        self.picking_type_out.must_be_packed = True
+        picking = self._make_picking(self.picking_type_out)
+        self._add_move_line(picking)
+        with self.assertRaises(UserError):
+            self._sanity_check(picking)
+
+    def test_error_only_for_unpackaged_lines(self):
+        """Mix of packed/unpacked lines - the unpacked one triggers the error."""
+        self.picking_type_out.must_be_packed = True
+        picking = self._make_picking(self.picking_type_out)
+        package = self.env["stock.package"].create({})
+        self._add_move_line(picking, result_package=package)
+        self._add_move_line(picking)  # no package
+        with self.assertRaises(UserError):
+            self._sanity_check(picking)
+
+    def test_no_error_when_must_be_packed_false_even_with_no_lines(self):
+        self.picking_type_out.must_be_packed = False
+        picking = self._make_picking(self.picking_type_out)
+        self._sanity_check(picking)  # must not raise

--- a/stock_picking_mandatory_packing/views/stock_picking_type.xml
+++ b/stock_picking_mandatory_packing/views/stock_picking_type.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <record id="view_picking_type_form" model="ir.ui.view">
+        <field name="name">view_picking_type_form</field>
+        <field name="model">stock.picking.type</field>
+        <field name="inherit_id" ref="stock.view_picking_type_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='set_package_type']" position="after">
+                <field name="must_be_packed" />
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
New module adding the ability to force mandatory packing on a given operation type.

**Dependencies:**
- N/A

**ARL (Associated Risk Level):**
- [x] Low
- [ ] Medium
- [ ] High

**Type of change:**
- [ ] Forwardport / Backport
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

