### PR TITLE
[19.0][ADD] sale_order_line_product_image

### DIFF
--- a/sale_order_line_product_image/README.rst
+++ b/sale_order_line_product_image/README.rst
@@ -1,0 +1,6 @@
+=============================sale_order_line
+sale_order_line_product_image
+=============================
+
+Add an optional product image to both the backend, and the sale order pdf.
+

--- a/sale_order_line_product_image/__init__.py
+++ b/sale_order_line_product_image/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/sale_order_line_product_image/__manifest__.py
+++ b/sale_order_line_product_image/__manifest__.py
@@ -1,0 +1,14 @@
+{
+    "name": "sale_order_line_product_image",
+    "summary": "Add an related product image to the sale order line",
+    "author": "Glo Networks",
+    "website": "https://github.com/GlodoUK/odoo-addons",
+    "category": "Uncategorized",
+    "version": "19.0.1.0.0",
+    "depends": ["sale", "product"],
+    "data": [
+        "report/sale_order_report.xml",
+        "views/sale_order.xml",
+    ],
+    "license": "LGPL-3",
+}

--- a/sale_order_line_product_image/models/__init__.py
+++ b/sale_order_line_product_image/models/__init__.py
@@ -1,0 +1,2 @@
+from . import sale_order
+from . import sale_order_line

--- a/sale_order_line_product_image/models/sale_order.py
+++ b/sale_order_line_product_image/models/sale_order.py
@@ -1,0 +1,13 @@
+from odoo import fields, models
+
+
+class SaleOrder(models.Model):
+    _inherit = "sale.order"
+
+    pdfs_show_product_image = fields.Selection(
+        [
+            ("product_image_128", "128x128"),
+            ("product_image_256", "256x256"),
+        ],
+        default=False,
+    )

--- a/sale_order_line_product_image/models/sale_order_line.py
+++ b/sale_order_line_product_image/models/sale_order_line.py
@@ -1,0 +1,20 @@
+from odoo import fields, models
+
+
+class SaleOrderLine(models.Model):
+    _inherit = "sale.order.line"
+
+    product_image_128 = fields.Image(
+        related="product_id.image_128",
+        store=False,
+    )
+
+    product_image_256 = fields.Image(
+        related="product_id.image_256",
+        store=False,
+    )
+
+    product_image_512 = fields.Image(
+        related="product_id.image_512",
+        store=False,
+    )

--- a/sale_order_line_product_image/pyproject.toml
+++ b/sale_order_line_product_image/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["whool"]
+build-backend = "whool.buildapi"

--- a/sale_order_line_product_image/report/sale_order_report.xml
+++ b/sale_order_line_product_image/report/sale_order_report.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <!--Inherits the sale order report template to add the image of the product in the report-->
+    <template
+        id="report_saleorder_document"
+        inherit_id="sale.report_saleorder_document"
+    >
+        <xpath
+            expr="//t[@t-foreach='lines_to_report']//td[@name='td_product_name']/span"
+            position="after"
+        >
+            <img
+                t-if="doc.pdfs_show_product_image and line[doc.pdfs_show_product_image]"
+                t-att-src="image_data_uri(line[doc.pdfs_show_product_image])"
+                class="d-block py-1"
+                alt=""
+            />
+        </xpath>
+    </template>
+</odoo>

--- a/sale_order_line_product_image/views/sale_order.xml
+++ b/sale_order_line_product_image/views/sale_order.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <record id="view_order_form" model="ir.ui.view">
+        <field name="name">view_order_form</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form" />
+        <field name="arch" type="xml">
+            <xpath
+                expr="//field[@name='order_line']//list/field[@name='sequence']"
+                position="after"
+            >#
+                <field
+                name="product_image_512"
+                widget="image"
+                invisible="not product_image_512"
+                options="{'zoom': true, 'preview_image': 'product_image_128'}"
+                optional="hidden"
+                string="Product Image"
+            />
+            </xpath>
+            <xpath
+                expr="//page[@name='other_information']//group[@name='sales_person']"
+                position="inside"
+            >
+                <field name="pdfs_show_product_image" />
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Adds an optional product image to both the sale order backend and the sale order pdfs

This is a generalisation of a previously created module. Under this 19.0 version it's much simplified due to the introduction of the zoomable image widget.

The sibling module stock_picking_product_image may be ported separately later.

Fixes T16873

**Dependencies:**
- N/A

**ARL (Associated Risk Level):**
- [x] Low
- [ ] Medium
- [ ] High

**Type of change:**
- [x] Forwardport / Backport
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

