### PR TITLE
[19.0][ADD] product_alternative,product_alternative_sale

### DIFF
--- a/product_alternative/README.rst
+++ b/product_alternative/README.rst
@@ -1,0 +1,7 @@
+===================
+product_alternative
+===================
+
+Adds a way to record relationships between products.
+
+Builds on the idea from ``website_sale``.

--- a/product_alternative/__init__.py
+++ b/product_alternative/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/product_alternative/__manifest__.py
+++ b/product_alternative/__manifest__.py
@@ -1,0 +1,15 @@
+{
+    "name": "product_alternative",
+    "summary": "Define alternative products",
+    "author": "Glo Networks",
+    "category": "Sales/Sales",
+    "version": "19.0.1.0.0",
+    "license": "LGPL-3",
+    "depends": ["product"],
+    "data": [
+        "security/ir.model.access.csv",
+        "views/product_alternative_views.xml",
+        "views/product_template_views.xml",
+    ],
+    "website": "https://github.com/GlodoUK/odoo-addons",
+}

--- a/product_alternative/models/__init__.py
+++ b/product_alternative/models/__init__.py
@@ -1,0 +1,2 @@
+from . import product_alternative
+from . import product_template

--- a/product_alternative/models/product_alternative.py
+++ b/product_alternative/models/product_alternative.py
@@ -1,0 +1,228 @@
+from ast import literal_eval
+
+from odoo import api, fields, models
+from odoo.exceptions import ValidationError
+
+
+class ProductAlternative(models.Model):
+    """Directional link declaring that ``product_tmpl_id`` has an alternative.
+
+    Both ends are scoped with a domain over ``product.product`` instead of a
+    fixed variant, which keeps a single, flexible mechanism:
+
+    * ``product_domain`` selects which variants of the *source* product the
+      link applies to (empty = every variant);
+    * ``alternative_domain`` narrows which variants of ``alternative_tmpl_id``
+      are proposed (empty = every variant).
+
+    A domain subsumes every granularity we need: ``[('id', '=', N)]`` pins one
+    specific variant, ``[]`` means the whole template, and attribute/category/
+    price filters express everything in between. Because alternatives are
+    resolved through ``search``/``filtered_domain`` (which only ever return
+    materialised, active records), the link stays valid for templates using
+    dynamic variants without ever forcing a variant to be created.
+    """
+
+    _name = "product.alternative"
+    _description = "Product Alternative Rule"
+    _inherit = ["mail.thread"]
+    _order = "sequence, id"
+    _check_company_auto = True
+
+    active = fields.Boolean(default=True, index=True)
+    sequence = fields.Integer(default=10, index=True)
+    # Defaults to 'domain' so existing records (and Odoo's backfill of this
+    # column onto them) keep their current domain behaviour.
+    mode = fields.Selection(
+        [("domain", "Domain"), ("specific", "Simple")],
+        required=True,
+        default="specific",
+        help="Domain: scope each side with a product domain. "
+        "Specific: link the templates directly, optionally pinning a single "
+        "variant on either side.",
+    )
+    product_tmpl_id = fields.Many2one(
+        "product.template",
+        string="Product",
+        required=True,
+        ondelete="cascade",
+        index=True,
+        help="Product this alternative is declared on.",
+        tracking=True,
+        check_company=True,
+    )
+    product_domain = fields.Char(
+        string="Applies To Domain",
+        default="[]",
+        help="Domain on product variants selecting which variants of this "
+        "product the alternative applies to. Leave empty to apply to "
+        "every variant. Used in Domain mode.",
+        tracking=True,
+    )
+    product_variant_ids = fields.Many2many(
+        "product.product",
+        relation="product_alternative_source_variant_rel",
+        column1="alternative_id",
+        column2="product_id",
+        string="Product Variants",
+        domain="[('product_tmpl_id', '=', product_tmpl_id)]",
+        help="In Specific mode, restrict the link to these source variants. "
+        "Leave empty to apply to every variant of the product.",
+        tracking=True,
+    )
+    alternative_tmpl_id = fields.Many2one(
+        "product.template",
+        string="Alternative Product",
+        ondelete="cascade",
+        index=True,
+        help="Product proposed as an alternative. Used in Specific mode only; "
+        "in Domain mode the alternatives are defined entirely by the domain, "
+        "which can match variants of any product.",
+        tracking=True,
+        check_company=True,
+    )
+    alternative_domain = fields.Char(
+        string="Alternative Variant Domain",
+        default="[]",
+        help="Domain on product variants selecting which variants are "
+        "proposed as alternatives, matched across all products. Used in "
+        "Domain mode. Leave empty to propose every variant of every product.",
+        tracking=True,
+    )
+    alternative_variant_ids = fields.Many2many(
+        "product.product",
+        relation="product_alternative_target_variant_rel",
+        column1="alternative_id",
+        column2="product_id",
+        string="Alternative Variants",
+        domain="[('product_tmpl_id', '=', alternative_tmpl_id)]",
+        help="In Specific mode, propose only these variants of the "
+        "alternative. Leave empty to propose every variant.",
+        tracking=True,
+    )
+    note = fields.Char()
+    company_id = fields.Many2one(
+        related="product_tmpl_id.company_id",
+        store=True,
+        index=True,
+    )
+    matched_variant_count = fields.Integer(
+        string="# Variants",
+        compute="_compute_matched_variant_count",
+        help="How many variants of the alternative product currently match.",
+        store=True,
+    )
+
+    @api.depends(
+        "mode",
+        "alternative_tmpl_id",
+        "alternative_domain",
+        "alternative_variant_ids",
+    )
+    def _compute_matched_variant_count(self):
+        for alternative in self:
+            alternative.matched_variant_count = len(
+                alternative._get_alternative_variants()
+            )
+
+    @api.onchange("mode")
+    def _onchange_mode(self):
+        # In domain mode the alternative is expressed purely through the
+        # domain, so the template-based fields must not be filled in.
+        if self.mode == "domain":
+            self.alternative_tmpl_id = False
+            self.alternative_variant_ids = False
+            self.product_variant_ids = False
+
+    @api.onchange("product_tmpl_id")
+    def _onchange_product_tmpl_id(self):
+        self.product_variant_ids = self.product_variant_ids.filtered(
+            lambda v: v.product_tmpl_id == self.product_tmpl_id
+        )
+
+    @api.onchange("alternative_tmpl_id")
+    def _onchange_alternative_tmpl_id(self):
+        self.alternative_variant_ids = self.alternative_variant_ids.filtered(
+            lambda v: v.product_tmpl_id == self.alternative_tmpl_id
+        )
+
+    @api.constrains("product_tmpl_id", "alternative_tmpl_id")
+    def _check_not_self(self):
+        for alternative in self:
+            if alternative.product_tmpl_id == alternative.alternative_tmpl_id:
+                raise ValidationError(
+                    self.env._("A product cannot be an alternative of itself.")
+                )
+
+    @api.constrains("mode", "alternative_tmpl_id")
+    def _check_alternative_template(self):
+        for alternative in self:
+            if alternative.mode == "specific" and not alternative.alternative_tmpl_id:
+                raise ValidationError(
+                    self.env._("An alternative product is required in Specific mode.")
+                )
+            if alternative.mode == "domain" and alternative.alternative_tmpl_id:
+                raise ValidationError(
+                    self.env._(
+                        "In Domain mode the alternatives are defined by the "
+                        "domain; leave the alternative product empty."
+                    )
+                )
+
+    @api.constrains("product_variant_ids", "product_tmpl_id")
+    def _check_product_variants(self):
+        for alternative in self:
+            if (
+                alternative.product_variant_ids.product_tmpl_id
+                - alternative.product_tmpl_id
+            ):
+                raise ValidationError(
+                    self.env._("The source variants must belong to the product.")
+                )
+
+    @api.constrains("alternative_variant_ids", "alternative_tmpl_id")
+    def _check_alternative_variants(self):
+        for alternative in self:
+            if (
+                alternative.alternative_variant_ids.product_tmpl_id
+                - alternative.alternative_tmpl_id
+            ):
+                raise ValidationError(
+                    self.env._(
+                        "The alternative variants must belong to the alternative"
+                        " product."
+                    )
+                )
+
+    def _matches_source_variant(self, variant):
+        """Whether ``variant`` (of the source product) is in this link's scope."""
+        self.ensure_one()
+        if self.mode == "specific":
+            # Pinned variants, or every variant of the source product.
+            return not self.product_variant_ids or variant in self.product_variant_ids
+        return bool(variant.filtered_domain(literal_eval(self.product_domain)))
+
+    def _get_alternative_variants(self):
+        """Resolve to currently-materialised ``product.product`` alternatives,
+        ignoring source-side scoping.
+
+        In domain mode the resolution runs through ``search``, which only
+        returns materialised, active records, so dynamic templates yield only
+        variants that already exist (never created speculatively). The domain
+        is matched across every product (it is not bound to a template), so
+        any leaf restricting the template must be part of the domain itself.
+        """
+        variants = self.env["product.product"]
+        for alternative in self:
+            if alternative.mode == "specific":
+                if not alternative.alternative_tmpl_id:
+                    continue
+                # Pinned variants, or every materialised variant of the target.
+                variants |= (
+                    alternative.alternative_variant_ids
+                    or alternative.alternative_tmpl_id.product_variant_ids
+                )
+                continue
+            domain = literal_eval(alternative.alternative_domain)
+            variants |= self.env["product.product"].search(domain)
+        return variants

--- a/product_alternative/models/product_template.py
+++ b/product_alternative/models/product_template.py
@@ -1,0 +1,26 @@
+from odoo import fields, models
+
+
+class ProductTemplate(models.Model):
+    _inherit = "product.template"
+
+    alternative_rule_ids = fields.One2many(
+        "product.alternative",
+        "product_tmpl_id",
+        string="Alternatives",
+        help="Products proposed as alternatives to this one.",
+    )
+
+
+class ProductProduct(models.Model):
+    _inherit = "product.product"
+
+    def _get_alternative_products(self):
+        """Return the resolved ``product.product`` alternatives for this
+        variant: the template's alternative definitions whose source-side scope
+        matches this variant, resolved to their target variants."""
+        self.ensure_one()
+        applicable = self.product_tmpl_id.alternative_rule_ids.filtered(
+            lambda alt: alt._matches_source_variant(self)
+        )
+        return applicable._get_alternative_variants()

--- a/product_alternative/pyproject.toml
+++ b/product_alternative/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["whool"]
+build-backend = "whool.buildapi"

--- a/product_alternative/security/ir.model.access.csv
+++ b/product_alternative/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_product_alternative_user,product.alternative user,model_product_alternative,base.group_user,1,0,0,0
+access_product_alternative_manager,product.alternative manager,model_product_alternative,product.group_product_manager,1,1,1,1

--- a/product_alternative/tests/__init__.py
+++ b/product_alternative/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_product_alternative

--- a/product_alternative/tests/test_product_alternative.py
+++ b/product_alternative/tests/test_product_alternative.py
@@ -1,0 +1,303 @@
+from odoo import Command
+from odoo.exceptions import ValidationError
+from odoo.tests.common import TransactionCase
+
+
+class TestProductAlternative(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        Attribute = cls.env["product.attribute"]
+        Value = cls.env["product.attribute.value"]
+        Template = cls.env["product.template"]
+
+        # Color / Size -> 'always' attributes, so variants materialise.
+        cls.color = Attribute.create({"name": "Color", "create_variant": "always"})
+        cls.red = Value.create({"name": "Red", "attribute_id": cls.color.id})
+        cls.blue = Value.create({"name": "Blue", "attribute_id": cls.color.id})
+        cls.size = Attribute.create({"name": "Size", "create_variant": "always"})
+        cls.small = Value.create({"name": "S", "attribute_id": cls.size.id})
+        cls.large = Value.create({"name": "L", "attribute_id": cls.size.id})
+
+        # Source has Color -> 2 variants (Red, Blue), so source-side scoping
+        # is meaningful.
+        cls.source = Template.create(
+            {
+                "name": "Source",
+                "attribute_line_ids": [
+                    Command.create(
+                        {
+                            "attribute_id": cls.color.id,
+                            "value_ids": [Command.set([cls.red.id, cls.blue.id])],
+                        }
+                    ),
+                ],
+            }
+        )
+        cls.target = Template.create(
+            {
+                "name": "Target",
+                "attribute_line_ids": [
+                    Command.create(
+                        {
+                            "attribute_id": cls.color.id,
+                            "value_ids": [Command.set([cls.red.id, cls.blue.id])],
+                        }
+                    ),
+                    Command.create(
+                        {
+                            "attribute_id": cls.size.id,
+                            "value_ids": [Command.set([cls.small.id, cls.large.id])],
+                        }
+                    ),
+                ],
+            }
+        )
+        # 2 colors x 2 sizes = 4 variants materialise automatically.
+
+        # Dynamic template -> no variant materialised up front.
+        cls.dyn_attr = Attribute.create(
+            {"name": "DynColor", "create_variant": "dynamic"}
+        )
+        cls.dyn_red = Value.create({"name": "DRed", "attribute_id": cls.dyn_attr.id})
+        cls.dyn_blue = Value.create({"name": "DBlue", "attribute_id": cls.dyn_attr.id})
+        cls.dyn_target = Template.create(
+            {
+                "name": "DynTarget",
+                "attribute_line_ids": [
+                    Command.create(
+                        {
+                            "attribute_id": cls.dyn_attr.id,
+                            "value_ids": [
+                                Command.set([cls.dyn_red.id, cls.dyn_blue.id])
+                            ],
+                        }
+                    ),
+                ],
+            }
+        )
+
+    @classmethod
+    def _ptav(cls, template, value):
+        return template.attribute_line_ids.product_template_value_ids.filtered(
+            lambda p: p.product_attribute_value_id == value
+        )
+
+    def _variant(self, template, *values):
+        ptavs = self.env["product.template.attribute.value"]
+        for value in values:
+            ptavs |= self._ptav(template, value)
+        return template.product_variant_ids.filtered(
+            lambda v: ptavs <= v.product_template_attribute_value_ids
+        )
+
+    def _has_value_domain(self, template, *values):
+        """Domain string matching variants carrying every listed value."""
+        leaves = [
+            ("product_template_attribute_value_ids", "in", self._ptav(template, v).ids)
+            for v in values
+        ]
+        return repr(leaves)
+
+    def _alternative(self, **vals):
+        vals.setdefault("product_tmpl_id", self.source.id)
+        # In domain mode the alternative is defined purely by the domain and
+        # no alternative template is allowed.
+        if vals.get("mode", "specific") != "domain":
+            vals.setdefault("alternative_tmpl_id", self.target.id)
+        return self.env["product.alternative"].create(vals)
+
+    def test_empty_matches_all_variants(self):
+        alt = self._alternative()
+        self.assertEqual(
+            alt._get_alternative_variants(), self.target.product_variant_ids
+        )
+        self.assertEqual(len(alt._get_alternative_variants()), 4)
+
+    def test_domain_filters_one_attribute(self):
+        # Red only -> Red/S and Red/L, sizes unconstrained.
+        alt = self._alternative(
+            mode="domain",
+            alternative_domain=self._has_value_domain(self.target, self.red),
+        )
+        result = alt._get_alternative_variants()
+        self.assertEqual(result, self._variant(self.target, self.red))
+        self.assertEqual(len(result), 2)
+
+    def test_domain_cross_attribute_is_and(self):
+        # Red AND Small -> exactly one variant.
+        alt = self._alternative(
+            mode="domain",
+            alternative_domain=self._has_value_domain(
+                self.target, self.red, self.small
+            ),
+        )
+        result = alt._get_alternative_variants()
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result, self._variant(self.target, self.red, self.small))
+
+    def test_domain_can_pin_single_variant_by_id(self):
+        # A domain subsumes the hyper-specific case.
+        variant = self._variant(self.target, self.blue, self.large)
+        alt = self._alternative(
+            mode="domain", alternative_domain=repr([("id", "=", variant.id)])
+        )
+        self.assertEqual(alt._get_alternative_variants(), variant)
+
+    def test_domain_bounded_to_alternative_template(self):
+        # An empty domain never leaks variants of other templates.
+        alt = self._alternative()
+        self.assertTrue(
+            all(
+                v.product_tmpl_id == self.target
+                for v in alt._get_alternative_variants()
+            )
+        )
+
+    def test_source_scoping_per_variant(self):
+        # Source Red variants -> Target Blue variants only.
+        self._alternative(
+            mode="domain",
+            product_domain=self._has_value_domain(self.source, self.red),
+            alternative_domain=self._has_value_domain(self.target, self.blue),
+        )
+        source_red = self._variant(self.source, self.red)
+        source_blue = self._variant(self.source, self.blue)
+        expected = self._variant(self.target, self.blue)
+
+        self.assertEqual(source_red._get_alternative_products(), expected)
+        self.assertEqual(len(expected), 2)
+        self.assertFalse(source_blue._get_alternative_products())
+
+    def test_empty_source_domain_applies_to_all_variants(self):
+        self._alternative(
+            mode="domain",
+            alternative_domain=self._has_value_domain(self.target, self.red),
+        )
+        expected = self._variant(self.target, self.red)
+        for variant in self.source.product_variant_ids:
+            self.assertEqual(variant._get_alternative_products(), expected)
+
+    def test_dynamic_empty_when_no_variant_materialised(self):
+        alt = self._alternative(
+            mode="domain",
+            alternative_domain=repr([("product_tmpl_id", "=", self.dyn_target.id)]),
+        )
+        self.assertFalse(alt._get_alternative_variants())
+        self.assertFalse(self.dyn_target.product_variant_ids)
+
+    def test_dynamic_matches_once_materialised(self):
+        combination = self._ptav(self.dyn_target, self.dyn_red)
+        variant = self.dyn_target._create_product_variant(combination)
+        self.assertTrue(variant)
+        alt = self._alternative(
+            mode="domain",
+            alternative_domain=repr(
+                [("product_template_attribute_value_ids", "in", combination.ids)]
+            ),
+        )
+        self.assertEqual(alt._get_alternative_variants(), variant)
+
+    def test_domain_without_alternative_template_matches_any_product(self):
+        # No alternative template in domain mode: the domain is matched against
+        # variants of any product, not bounded to a single template.
+        alt = self._alternative(
+            mode="domain",
+            alternative_tmpl_id=False,
+            alternative_domain=repr(
+                [("product_tmpl_id", "in", [self.source.id, self.target.id])]
+            ),
+        )
+        expected = self.source.product_variant_ids | self.target.product_variant_ids
+        self.assertEqual(alt._get_alternative_variants(), expected)
+        self.assertEqual(len(expected), 6)
+
+    def test_domain_without_alternative_template_allowed(self):
+        # Domain mode does not require an alternative template.
+        alt = self._alternative(mode="domain", alternative_tmpl_id=False)
+        self.assertTrue(alt)
+
+    def test_specific_mode_requires_alternative_template(self):
+        with self.assertRaises(ValidationError):
+            self._alternative(mode="specific", alternative_tmpl_id=False)
+
+    def test_domain_mode_forbids_alternative_template(self):
+        with self.assertRaises(ValidationError):
+            self._alternative(mode="domain", alternative_tmpl_id=self.target.id)
+
+    def test_cannot_be_alternative_of_self(self):
+        with self.assertRaises(ValidationError):
+            self._alternative(mode="specific", alternative_tmpl_id=self.source.id)
+
+    def test_matched_variant_count(self):
+        alt = self._alternative(
+            mode="domain",
+            alternative_domain=self._has_value_domain(self.target, self.red),
+        )
+        self.assertEqual(alt.matched_variant_count, 2)
+
+    def test_specific_mode_template_to_template(self):
+        self._alternative(mode="specific")
+        for variant in self.source.product_variant_ids:
+            self.assertEqual(
+                variant._get_alternative_products(),
+                self.target.product_variant_ids,
+            )
+
+    def test_specific_mode_pins_target_variants(self):
+        targets = self._variant(self.target, self.blue, self.large) | self._variant(
+            self.target, self.red, self.small
+        )
+        self._alternative(
+            mode="specific",
+            alternative_variant_ids=[Command.set(targets.ids)],
+        )
+        for variant in self.source.product_variant_ids:
+            self.assertEqual(variant._get_alternative_products(), targets)
+
+    def test_specific_mode_pins_source_variant(self):
+        source_red = self._variant(self.source, self.red)
+        source_blue = self._variant(self.source, self.blue)
+        self._alternative(
+            mode="specific",
+            product_variant_ids=[Command.set(source_red.ids)],
+        )
+        self.assertEqual(
+            source_red._get_alternative_products(), self.target.product_variant_ids
+        )
+        self.assertFalse(source_blue._get_alternative_products())
+
+    def test_specific_mode_pins_both_sides(self):
+        source_red = self._variant(self.source, self.red)
+        source_blue = self._variant(self.source, self.blue)
+        target_variant = self._variant(self.target, self.blue, self.small)
+        self._alternative(
+            mode="specific",
+            product_variant_ids=[Command.set(source_red.ids)],
+            alternative_variant_ids=[Command.set(target_variant.ids)],
+        )
+        self.assertEqual(source_red._get_alternative_products(), target_variant)
+        self.assertFalse(source_blue._get_alternative_products())
+
+    def test_specific_source_variant_must_belong_to_product(self):
+        with self.assertRaises(ValidationError):
+            self._alternative(
+                mode="specific",
+                product_variant_ids=[
+                    Command.set(self._variant(self.target, self.red, self.small).ids)
+                ],
+            )
+
+    def test_specific_alternative_variant_must_belong(self):
+        with self.assertRaises(ValidationError):
+            self._alternative(
+                mode="specific",
+                alternative_variant_ids=[
+                    Command.set(self._variant(self.source, self.red).ids)
+                ],
+            )
+
+    def test_invalid_domain_ignored_in_specific_mode(self):
+        # Domain validation is skipped when the mode is not 'domain'.
+        alt = self._alternative(mode="specific", alternative_domain="not a domain")
+        self.assertTrue(alt)

--- a/product_alternative/views/product_alternative_views.xml
+++ b/product_alternative/views/product_alternative_views.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <record id="product_alternative_view_list" model="ir.ui.view">
+        <field name="name">product.alternative.list</field>
+        <field name="model">product.alternative</field>
+        <field name="arch" type="xml">
+            <list>
+                <field name="sequence" widget="handle" />
+                <field name="mode" />
+                <field name="product_tmpl_id" />
+                <field name="alternative_tmpl_id" />
+                <field name="matched_variant_count" />
+                <field name="note" optional="show" />
+                <field name="company_id" column_invisible="1" />
+            </list>
+        </field>
+    </record>
+
+    <record id="product_alternative_view_form" model="ir.ui.view">
+        <field name="name">product.alternative.form</field>
+        <field name="model">product.alternative</field>
+        <field name="arch" type="xml">
+            <form>
+                <sheet>
+                    <group>
+                        <field
+                            name="mode"
+                            widget="radio"
+                            options="{'horizontal': True}"
+                        />
+                    </group>
+                    <group>
+                        <group string="Product">
+                            <field name="product_tmpl_id" />
+                            <field
+                                name="product_domain"
+                                widget="domain"
+                                options="{'model': 'product.product'}"
+                                invisible="mode != 'domain'"
+                            />
+                            <field
+                                name="product_variant_ids"
+                                widget="many2many_tags"
+                                options="{'no_create': True}"
+                                invisible="mode != 'specific'"
+                            />
+                        </group>
+                        <group string="Alternative">
+                            <field
+                                name="alternative_tmpl_id"
+                                required="mode == 'specific'"
+                                invisible="mode != 'specific'"
+                            />
+                            <field
+                                name="alternative_domain"
+                                widget="domain"
+                                options="{'model': 'product.product'}"
+                                invisible="mode != 'domain'"
+                            />
+                            <field
+                                name="alternative_variant_ids"
+                                widget="many2many_tags"
+                                options="{'no_create': True}"
+                                invisible="mode != 'specific'"
+                            />
+                            <field name="matched_variant_count" />
+                        </group>
+                        <group colspan="12">
+                            <field name="note" />
+                            <field name="sequence" />
+                        </group>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+</odoo>

--- a/product_alternative/views/product_template_views.xml
+++ b/product_alternative/views/product_template_views.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <record id="product_template_form_view_alternative" model="ir.ui.view">
+        <field name="name">product.template.form.alternative</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="product.product_template_form_view" />
+        <field name="arch" type="xml">
+            <xpath expr="//notebook" position="inside">
+                <page string="Alternatives" name="alternatives">
+                    <field
+                        name="alternative_rule_ids"
+                        context="{'default_product_tmpl_id': id}"
+                    >
+                        <list>
+                            <field name="sequence" widget="handle" />
+                            <field name="mode" />
+                            <field name="matched_variant_count" string="# Variants" />
+                            <field name="note" optional="show" />
+                            <field name="active" optional="hide" />
+                        </list>
+                    </field>
+                </page>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/product_alternative_sale/README.rst
+++ b/product_alternative_sale/README.rst
@@ -1,0 +1,17 @@
+========================
+product_alternative_sale
+========================
+
+Adds a popup widget to the sale order line that lists a product's alternatives and
+opens the product catalog restricted to them.
+
+Known limitation (dynamic variants)
+------------------------------------
+The sale catalog and the line widget both operate on ``product.product``
+(materialised variants). Alternatives that resolve to a **dynamic** template
+with no materialised variants will therefore not appear, and a new dynamic
+configuration cannot be created from here - that requires the product
+configurator, which is intentionally out of scope.
+
+Dynamic alternatives only surface their already-materialised variants.
+

--- a/product_alternative_sale/__init__.py
+++ b/product_alternative_sale/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/product_alternative_sale/__manifest__.py
+++ b/product_alternative_sale/__manifest__.py
@@ -1,0 +1,19 @@
+{
+    "name": "product_alternative_sale",
+    "summary": "Show a product's alternatives on the sale order line in a popup",
+    "author": "Glo Networks",
+    "category": "Sales/Sales",
+    "version": "19.0.1.0.0",
+    "license": "LGPL-3",
+    "depends": ["sale", "product_alternative"],
+    "data": [
+        "views/product_alternative_menus.xml",
+        "views/sale_order_views.xml",
+    ],
+    "assets": {
+        "web.assets_backend": [
+            "product_alternative_sale/static/src/**/*",
+        ],
+    },
+    "website": "https://github.com/GlodoUK/odoo-addons",
+}

--- a/product_alternative_sale/models/__init__.py
+++ b/product_alternative_sale/models/__init__.py
@@ -1,0 +1,3 @@
+from . import product_product
+from . import sale_order
+from . import sale_order_line

--- a/product_alternative_sale/models/product_product.py
+++ b/product_alternative_sale/models/product_product.py
@@ -1,0 +1,25 @@
+from odoo import models
+
+
+class ProductProduct(models.Model):
+    _inherit = "product.product"
+
+    def get_alternatives_preview(self, limit=None, sale_ok=True):
+        """
+        Display data for the order-line popover: the first ``limit``
+        sellable alternatives plus a count of how many more there are.
+        """
+        self.ensure_one()
+        if limit is None:
+            limit = 5
+        alternatives = self._get_alternative_products()
+        if sale_ok:
+            alternatives = alternatives.filtered("sale_ok")
+        preview = alternatives[:limit]
+        return {
+            "alternatives": [
+                {"id": product.id, "display_name": product.display_name}
+                for product in preview
+            ],
+            "remaining": len(alternatives) - len(preview),
+        }

--- a/product_alternative_sale/models/sale_order.py
+++ b/product_alternative_sale/models/sale_order.py
@@ -1,0 +1,16 @@
+from odoo import models
+from odoo.fields import Domain
+
+
+class SaleOrder(models.Model):
+    _inherit = "sale.order"
+
+    def _get_product_catalog_domain(self):
+        """Restrict the catalog to a set of variants when opened from the
+        alternatives popover (context key set by
+        ``sale.order.line.action_view_alternatives_catalog``)."""
+        domain = super()._get_product_catalog_domain()
+        variant_ids = self.env.context.get("product_alternative_sale_ids")
+        if variant_ids:
+            domain &= Domain("id", "in", variant_ids)
+        return domain

--- a/product_alternative_sale/models/sale_order_line.py
+++ b/product_alternative_sale/models/sale_order_line.py
@@ -1,0 +1,41 @@
+from odoo import api, fields, models
+
+
+class SaleOrderLine(models.Model):
+    _inherit = "sale.order.line"
+
+    display_alternatives_widget = fields.Boolean(
+        compute="_compute_display_alternatives_widget",
+    )
+
+    @api.depends("product_id")
+    def _compute_display_alternatives_widget(self):
+        # Materialised variants only: _get_alternative_products() never creates
+        # variants. Alternatives on a dynamic template with no materialised
+        # variants therefore won't appear here or in the catalog -- ordering a
+        # new dynamic configuration would need the configurator (out of scope).
+        for line in self:
+            matched = False
+            if not line.product_id:
+                line.display_alternatives_widget = False
+                continue
+
+            for alternative in line.product_id.product_tmpl_id.alternative_rule_ids:
+                if not alternative._matches_source_variant(self):
+                    continue
+                if alternative._get_alternative_variants().filtered("sale_ok"):
+                    matched = True
+                    break
+
+            line.display_alternatives_widget = matched
+
+    def action_view_alternatives_catalog(self):
+        """Open the product catalog for this line's order, restricted to this
+        line's alternative variants."""
+        self.ensure_one()
+        return self.with_context(
+            order_id=self.order_id.id,
+            product_alternative_sale_ids=self.product_id._get_alternative_products()
+            .filtered("sale_ok")
+            .ids,
+        ).action_add_from_catalog()

--- a/product_alternative_sale/pyproject.toml
+++ b/product_alternative_sale/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["whool"]
+build-backend = "whool.buildapi"

--- a/product_alternative_sale/static/src/product_alternatives_widget.esm.js
+++ b/product_alternative_sale/static/src/product_alternatives_widget.esm.js
@@ -1,0 +1,83 @@
+import {Component} from "@odoo/owl";
+import {_t} from "@web/core/l10n/translation";
+import {registry} from "@web/core/registry";
+import {standardWidgetProps} from "@web/views/widgets/standard_widget_props";
+import {usePopover} from "@web/core/popover/popover_hook";
+import {useService} from "@web/core/utils/hooks";
+
+export class ProductAlternativesPopover extends Component {
+    static template = "product_alternative_sale.ProductAlternativesPopover";
+    static props = {
+        close: Function,
+        alternatives: Array,
+        remainingCount: Number,
+        lineId: [Number, Boolean],
+    };
+
+    setup() {
+        this.orm = useService("orm");
+        this.action = useService("action");
+    }
+
+    get title() {
+        return _t("Alternative Products");
+    }
+
+    async viewCatalog() {
+        const action = await this.orm.call(
+            "sale.order.line",
+            "action_view_alternatives_catalog",
+            [[this.props.lineId]]
+        );
+        this.props.close();
+        await this.action.doAction(action);
+    }
+}
+
+export class ProductAlternativesWidget extends Component {
+    static components = {Popover: ProductAlternativesPopover};
+    static template = "product_alternative_sale.ProductAlternatives";
+    static props = {...standardWidgetProps};
+
+    setup() {
+        this.popover = usePopover(this.constructor.components.Popover, {
+            position: "top",
+        });
+        this.orm = useService("orm");
+    }
+
+    async showPopup(ev) {
+        // Capture the target before awaiting: the browser nulls
+        // ev.currentTarget once the handler yields (see sale_stock QtyAtDate).
+        const target = ev.currentTarget;
+        // Resolve the alternatives lazily, only now that the popover is opening.
+        // Keyed on the product (always a real id) so this works on unsaved
+        // lines; the server returns just the preview plus an "X more" count.
+        const productId = this.props.record.data.product_id.id;
+        const {alternatives, remaining} = await this.orm.call(
+            "product.product",
+            "get_alternatives_preview",
+            [[productId]]
+        );
+        // The catalog button needs a saved line; new records carry a virtual
+        // (string) resId, so only pass a numeric id.
+        const resId = this.props.record.resId;
+        this.popover.open(target, {
+            alternatives,
+            remainingCount: remaining,
+            lineId: typeof resId === "number" ? resId : false,
+        });
+    }
+}
+
+export const productAlternativesWidget = {
+    component: ProductAlternativesWidget,
+    fieldDependencies: [
+        {name: "display_alternatives_widget", type: "boolean"},
+        {name: "product_id", type: "many2one"},
+    ],
+};
+
+registry
+    .category("view_widgets")
+    .add("product_alternatives_widget", productAlternativesWidget);

--- a/product_alternative_sale/static/src/product_alternatives_widget.xml
+++ b/product_alternative_sale/static/src/product_alternatives_widget.xml
@@ -1,0 +1,35 @@
+<?xml version='1.0' encoding='utf-8' ?>
+<templates xml:space="preserve">
+
+    <t t-name="product_alternative_sale.ProductAlternatives">
+        <a
+            t-if="props.record.data.display_alternatives_widget"
+            t-on-click="showPopup"
+            class="fa fa-exchange cursor-pointer text-info"
+            title="Alternative products available"
+        />
+    </t>
+
+    <t t-name="product_alternative_sale.ProductAlternativesPopover">
+        <div class="p-2">
+            <h6 t-out="title" />
+            <ul class="ps-3 mb-0">
+                <li t-foreach="props.alternatives" t-as="alt" t-key="alt.id">
+                    <t t-out="alt.display_name" />
+                </li>
+            </ul>
+            <p t-if="props.remainingCount" class="text-muted fst-italic mb-0 mt-1">
+                There are <t t-out="props.remainingCount" /> more...
+            </p>
+            <button
+                t-if="props.lineId"
+                class="btn btn-link text-start ps-0"
+                type="button"
+                t-on-click="viewCatalog"
+            >
+                <i class="oi oi-fw o_button_icon oi-arrow-right" /> View in Catalog
+            </button>
+        </div>
+    </t>
+
+</templates>

--- a/product_alternative_sale/tests/__init__.py
+++ b/product_alternative_sale/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_sale_order_line_alternatives

--- a/product_alternative_sale/tests/test_sale_order_line_alternatives.py
+++ b/product_alternative_sale/tests/test_sale_order_line_alternatives.py
@@ -1,0 +1,45 @@
+from odoo import Command
+from odoo.tests.common import TransactionCase
+
+
+class TestSaleOrderLineAlternatives(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        Template = cls.env["product.template"]
+        cls.target = Template.create({"name": "Alt Target", "list_price": 50.0})
+        cls.source = Template.create({"name": "Alt Source", "list_price": 100.0})
+        cls.no_alt = Template.create({"name": "No Alternatives"})
+        cls.env["product.alternative"].create(
+            {
+                "product_tmpl_id": cls.source.id,
+                "alternative_tmpl_id": cls.target.id,
+            }
+        )
+        cls.partner = cls.env["res.partner"].create({"name": "Customer"})
+
+    def _line(self, product):
+        order = self.env["sale.order"].create(
+            {
+                "partner_id": self.partner.id,
+                "order_line": [Command.create({"product_id": product.id})],
+            }
+        )
+        return order.order_line
+
+    def test_widget_shows_alternatives(self):
+        line = self._line(self.source.product_variant_id)
+        self.assertTrue(line.display_alternatives_widget)
+
+    def test_widget_hidden_without_alternatives(self):
+        line = self._line(self.no_alt.product_variant_id)
+        self.assertFalse(line.display_alternatives_widget)
+
+    def test_catalog_action_restricted_to_alternatives(self):
+        line = self._line(self.source.product_variant_id)
+        action = line.action_view_alternatives_catalog()
+        self.assertEqual(action["res_model"], "product.product")
+        matched = self.env["product.product"].search(action["domain"])
+        self.assertIn(self.target.product_variant_id, matched)
+        self.assertNotIn(self.source.product_variant_id, matched)
+        self.assertNotIn(self.no_alt.product_variant_id, matched)

--- a/product_alternative_sale/views/product_alternative_menus.xml
+++ b/product_alternative_sale/views/product_alternative_menus.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <record id="product_alternative_action" model="ir.actions.act_window">
+        <field name="name">Product Alternatives</field>
+        <field name="res_model">product.alternative</field>
+        <field name="view_mode">list,form</field>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                Create a product alternative rule
+            </p>
+            <p>
+                Declare that a product has alternatives to propose them on sale order lines.
+            </p>
+        </field>
+    </record>
+
+    <menuitem
+        id="product_alternative_menu"
+        name="Product Alternatives"
+        parent="sale.product_menu_catalog"
+        action="product_alternative_action"
+        sequence="20"
+    />
+</odoo>

--- a/product_alternative_sale/views/sale_order_views.xml
+++ b/product_alternative_sale/views/sale_order_views.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <record id="view_order_form_alternatives" model="ir.ui.view">
+        <field name="name">sale.order.form.alternatives</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form" />
+        <field name="arch" type="xml">
+            <!-- order line list -->
+            <xpath
+                expr="//field[@name='order_line']//list//field[@name='product_uom_qty']"
+                position="before"
+            >
+                <widget name="product_alternatives_widget" width="20px" />
+            </xpath>
+            <!-- order line form (mobile / expanded) -->
+            <xpath
+                expr="//field[@name='order_line']//form//field[@name='product_uom_qty']"
+                position="before"
+            >
+                <widget name="product_alternatives_widget" />
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Adds a way to have alternative products and surface them on Odoo without needing website_sale installed. Allows for more advanced rules

Fixes T16897

**Dependencies:**
- N/A

**ARL (Associated Risk Level):**
- [ ] Low
- [x] Medium
- [ ] High

**Type of change:**
- [ ] Forwardport / Backport
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

