### PR TITLE
[19.0][ADD] shoehorn

### DIFF
--- a/shoehorn/README.rst
+++ b/shoehorn/README.rst
@@ -20,7 +20,7 @@ transaction.
 
 .. code-block:: sh
 
-    odoo shoehorn apply --shoehorn-path ./bootstrap -c /etc/odoo/odoo.conf
+    odoo shoehorn apply ./bootstrap -c /etc/odoo/odoo.conf
 
 The engine versions with Odoo itself: this branch targets Odoo 19.
 
@@ -79,8 +79,8 @@ and tracked independently:
 
 .. code-block:: sh
 
-    odoo shoehorn apply --shoehorn-path ./bootstrap -c /etc/odoo/odoo.conf
-    odoo shoehorn apply --shoehorn-path ./fixup_t12345 -c /etc/odoo/odoo.conf
+    odoo shoehorn apply ./bootstrap -c /etc/odoo/odoo.conf
+    odoo shoehorn apply ./fixup_t12345 -c /etc/odoo/odoo.conf
 
 The namespace can be pinned explicitly with ``--shoehorn-namespace NAME``,
 which takes precedence over the basename. Two consequences of "the basename
@@ -105,9 +105,9 @@ Generating migrations
 
 .. code-block:: sh
 
-    odoo shoehorn generate add_a_thing --shoehorn-path ./bootstrap      # .py (default)
-    odoo shoehorn generate res_partner.xml --shoehorn-path ./bootstrap  # data file
-    odoo shoehorn generate ir.model.access.csv --shoehorn-path ./bootstrap  # data file
+    odoo shoehorn generate ./bootstrap add_a_thing          # .py (default)
+    odoo shoehorn generate ./bootstrap res_partner.xml      # data file
+    odoo shoehorn generate ./bootstrap ir.model.access.csv  # data file
 
 creates e.g. ``20260604164512_add_a_thing.py`` with the conventional stub.
 
@@ -151,10 +151,9 @@ Reusable helpers for ``.py`` migrations live in ``shoehorn/tools/``:
 CLI
 ===
 
-- ``odoo shoehorn generate NAME --shoehorn-path DIR`` - create a new
-  migration (NAME may carry a ``.py``/``.xml``/``.csv``/``.sql`` extension;
-  defaults to ``.py``).
-- ``odoo shoehorn apply --shoehorn-path DIR`` - apply pending migrations.
+- ``odoo shoehorn generate DIR NAME`` - create a new migration (NAME may
+  carry a ``.py``/``.xml``/``.csv``/``.sql`` extension; defaults to ``.py``).
+- ``odoo shoehorn apply DIR`` - apply pending migrations.
   ``--shoehorn-namespace NAME`` overrides the namespace (default: DIR's
   basename). ``--neutralize`` runs ``odoo neutralize`` afterwards. Anything
   unrecognised is passed through to Odoo's config parser (``-c``, ``-d``,

--- a/shoehorn/README.rst
+++ b/shoehorn/README.rst
@@ -22,10 +22,19 @@ transaction.
 
     odoo shoehorn apply --shoehorn-path ./bootstrap -c /etc/odoo/odoo.conf
 
-The module only needs to be on the addons path - Odoo discovers the command
-from ``cli/shoehorn.py`` by filesystem convention; installing the module into
-a database is a harmless no-op. The engine versions with Odoo itself: this
-branch targets Odoo 19.
+The engine versions with Odoo itself: this branch targets Odoo 19.
+
+Installation
+============
+
+shoehorn is **not installed like a normal module**. The ``odoo shoehorn``
+CLI command (both ``apply`` and ``generate``) is discovered by filesystem
+convention from ``cli/shoehorn.py``, so having the module on the addons path
+is all the CLI needs - it does not have to be added to a database.
+
+Installing the module into a database is optional. It changes nothing about
+how the CLI works; it only adds a *Settings > Technical > Generate shoehorn
+migration* wizard - a UI front-end for ``generate`` (see below).
 
 Usage
 =====
@@ -101,6 +110,11 @@ Generating migrations
     odoo shoehorn generate ir.model.access.csv --shoehorn-path ./bootstrap  # data file
 
 creates e.g. ``20260604164512_add_a_thing.py`` with the conventional stub.
+
+When the module is installed, the same thing is available from the UI via
+*Settings > Technical > Generate shoehorn migration*: a minimal wizard taking
+a directory, a file type and a name. It calls the same ``generate`` code, so
+the naming, validation and stub templates are identical to the CLI.
 
 Conventions
 ===========

--- a/shoehorn/README.rst
+++ b/shoehorn/README.rst
@@ -1,0 +1,147 @@
+========
+shoehorn
+========
+
+Repeatedly and safely bootstrap Odoo databases.
+
+shoehorn applies a directory of one-shot setup steps ("migrations") to a
+database, tracking what has already been applied in the database itself - so
+the same command can be applied against a fresh database, a half-bootstrapped
+one, or a finished one, and always converges. It takes its inspiration from
+Rails migrations and `camptocamp/marabunta
+<https://github.com/camptocamp/marabunta>`__.
+
+
+Plain `click-odoo <https://github.com/acsone/click-odoo>`__ scripts are
+problematic because of the requirement to commit between steps: module installs
+reset the registry mid-run, and later steps depend on the committed results
+of earlier ones - so every migration gets its own registry, environment and
+transaction.
+
+.. code-block:: sh
+
+    odoo shoehorn apply --shoehorn-path ./bootstrap -c /etc/odoo/odoo.conf
+
+The module only needs to be on the addons path - Odoo discovers the command
+from ``cli/shoehorn.py`` by filesystem convention; installing the module into
+a database is a harmless no-op. The engine versions with Odoo itself: this
+branch targets Odoo 19.
+
+Usage
+=====
+
+A migration directory contains files named
+
+.. code-block:: text
+
+    YYYYMMDDHHMMSS_name.{py,xml,csv,sql}
+
+e.g. ``20260604100000_install_modules.py``. Ordering is the filename sort;
+the timestamp is the migration's identity.
+
+``apply`` applies whatever is **pending**, in filename order, each in its own
+transaction with a fresh registry. Applied migrations are recorded (by
+timestamp) as a JSON list under an ``ir.config_parameter``
+(``shoehorn.applied.<namespace>``) in the target database, written in the
+same transaction as the migration - the log entry exists if and only if the
+migration committed. So:
+
+- a fresh/dropped database starts from zero, automatically;
+- re-running after a failure picks up exactly where it stopped;
+- there is no resume, rerun or rollback - never edit an applied migration,
+  write a new one.
+
+The module list is refreshed (``ir.module.module.update_list``) on every
+invocation, before pending shoehorns are applied.
+
+Concurrent runs are guarded by a session-level Postgres advisory lock held
+for the duration of the run - a second ``apply`` against the same database
+fails fast rather than queueing (mirroring Rails'
+``ConcurrentMigrationError``). The lock is per database, not per namespace:
+migrations from different directories touch the same modules and records.
+
+Namespaces
+==========
+
+The directory's basename is the migration **namespace**, and each namespace
+has its own applied log. So alongside a long-lived ``./bootstrap`` directory
+you can keep separate directories for one-off complex fix-ups, each applied
+and tracked independently:
+
+.. code-block:: sh
+
+    odoo shoehorn apply --shoehorn-path ./bootstrap -c /etc/odoo/odoo.conf
+    odoo shoehorn apply --shoehorn-path ./fixup_t12345 -c /etc/odoo/odoo.conf
+
+The namespace can be pinned explicitly with ``--shoehorn-namespace NAME``,
+which takes precedence over the basename. Two consequences of "the basename
+is the identity" when it is not pinned:
+
+- **renaming a directory renames the namespace** - the new name starts from
+  an empty log (everything is pending again) and a fresh ir.model.data
+  module (re-applying creates duplicate records instead of updating);
+- two different paths with the same basename share a log.
+
+Namespaces must match ``[a-z0-9][a-z0-9_]*`` (no dots or dashes - the
+namespace is embedded in xmlids, which split on the first dot).
+
+Records created by data migrations are namespaced per migration namespace
+(``__shoehorn_<namespace>__``), so directories can't silently clobber each
+other's records by reusing an id. Referencing or updating another
+namespace's records is still possible, just explicit:
+``<record id="__shoehorn_bootstrap__.some_record">``.
+
+Generating migrations
+=====================
+
+.. code-block:: sh
+
+    odoo shoehorn generate add_a_thing --shoehorn-path ./bootstrap      # .py (default)
+    odoo shoehorn generate res_partner.xml --shoehorn-path ./bootstrap  # data file
+    odoo shoehorn generate ir.model.access.csv --shoehorn-path ./bootstrap  # data file
+
+creates e.g. ``20260604164512_add_a_thing.py`` with the conventional stub.
+
+Conventions
+===========
+
+- ``.py`` migrations must define ``up(env)``. Context is passed as keyword
+  arguments to whichever of these parameters the function declares (or all
+  of them via ``**kwargs``): ``namespace``, and ``module`` - the namespace's
+  ir.model.data module, for xmlids consistent with data files, e.g.
+  ``def up(env, module): env.ref(f"{module}.some_record")``.
+- ``.xml``/``.csv``/``.sql`` are loaded via ``odoo.tools.convert``; records
+  are namespaced under the ``__shoehorn_<namespace>__`` ir.model.data
+  module. For ``.csv`` the name part of the filename must be the model name
+  (``..._res.partner.csv``).
+- Subdirectories and non-migration extensions are ignored - keep assets
+  (logos etc.) and READMEs there.
+- Files with migration extensions that don't match the naming convention are
+  an error, not a warning.
+- Prefer data files over Python: XML can update existing records
+  (``<record id="base.main_company">``) and execute wizards
+  (``<function model="res.config.settings" name="execute">``). Use ``.py``
+  for what XML can't express - e.g. binary fields, which
+  ``<field file="..."/>`` can't load outside a real addon directory.
+
+Reusable helpers for ``.py`` migrations live in ``shoehorn/tools/``:
+
+.. code-block:: python
+
+    from odoo.addons.shoehorn.tools import (
+        install_modules,           # install_modules(env, ["sale", "stock"])
+        install_addons_yaml,       # doodba addons.yaml (explicitly named addons)
+        install_private_modules,   # everything in src/private
+    )
+
+CLI
+===
+
+- ``odoo shoehorn generate NAME --shoehorn-path DIR`` - create a new
+  migration (NAME may carry a ``.py``/``.xml``/``.csv``/``.sql`` extension;
+  defaults to ``.py``).
+- ``odoo shoehorn apply --shoehorn-path DIR`` - apply pending migrations.
+  ``--shoehorn-namespace NAME`` overrides the namespace (default: DIR's
+  basename). ``--neutralize`` runs ``odoo neutralize`` afterwards. Anything
+  unrecognised is passed through to Odoo's config parser (``-c``, ``-d``,
+  ...).

--- a/shoehorn/__init__.py
+++ b/shoehorn/__init__.py
@@ -1,3 +1,6 @@
-# Intentionally empty. The `odoo shoehorn` CLI command is discovered by
-# filesystem convention (cli/shoehorn.py); nothing needs importing when this
-# module is installed in a database.
+# The `odoo shoehorn` CLI command is discovered by filesystem convention
+# (cli/shoehorn.py) and needs nothing from here. The models below are only
+# used when the module is actually installed in a database, where they back
+# the "Generate shoehorn migration" wizard; importing them is cheap (class
+# definitions, no database access) and so harmless during CLI-only use.
+from . import wizards

--- a/shoehorn/__init__.py
+++ b/shoehorn/__init__.py
@@ -1,0 +1,3 @@
+# Intentionally empty. The `odoo shoehorn` CLI command is discovered by
+# filesystem convention (cli/shoehorn.py); nothing needs importing when this
+# module is installed in a database.

--- a/shoehorn/__manifest__.py
+++ b/shoehorn/__manifest__.py
@@ -7,6 +7,11 @@
     "version": "19.0.1.0.0",
     "depends": ["base"],
     "license": "Other proprietary",
-    # The CLI command works from the addons path alone; installing this
-    # module into a database is a harmless no-op.
+    "data": [
+        "security/ir.model.access.csv",
+        "views/generate_wizard_views.xml",
+    ],
+    # The CLI command works from the addons path alone, without installing.
+    # Installing this module only adds the "Generate shoehorn migration"
+    # wizard under Settings > Technical.
 }

--- a/shoehorn/__manifest__.py
+++ b/shoehorn/__manifest__.py
@@ -1,0 +1,12 @@
+{
+    "name": "shoehorn",
+    "summary": "Repeatedly and safely bootstrap Odoo databases (odoo shoehorn)",
+    "author": "Glo Networks",
+    "website": "https://github.com/GlodoUK/odoo-addons",
+    "category": "Technical",
+    "version": "19.0.1.0.0",
+    "depends": ["base"],
+    "license": "Other proprietary",
+    # The CLI command works from the addons path alone; installing this
+    # module into a database is a harmless no-op.
+}

--- a/shoehorn/cli/__init__.py
+++ b/shoehorn/cli/__init__.py
@@ -1,0 +1,1 @@
+# Intentionally empty. See ../__init__.py.

--- a/shoehorn/cli/shoehorn.py
+++ b/shoehorn/cli/shoehorn.py
@@ -1,0 +1,82 @@
+import argparse
+
+import odoo
+import odoo.cli.neutralize
+from odoo.cli.command import Command
+
+# Absolute imports are required: this file is loaded as ``odoo.cli.shoehorn``
+# (see odoo/cli/command.py load_addons_commands), so relative imports would
+# resolve against ``odoo.cli``, not this addon.
+# pylint: disable=odoo-addons-relative-import
+from odoo.addons.shoehorn.generate import generate
+from odoo.addons.shoehorn.migration import migrate
+
+
+class Shoehorn(Command):
+    """Repeatedly and safely bootstrap Odoo databases"""
+
+    def run(self, cmdargs):
+        parser = argparse.ArgumentParser(
+            prog="odoo shoehorn",
+            description="Repeatedly and safely bootstrap Odoo databases."
+            " Inspired by Rails migrations and camptocamp/marabunta.",
+        )
+        subparsers = parser.add_subparsers(dest="command", required=True)
+
+        common = argparse.ArgumentParser(add_help=False)
+        common.add_argument(
+            "--shoehorn-path",
+            required=True,
+            metavar="DIR",
+            help="Directory of shoehorn files (YYYYMMDDHHMMSS_name.{py,xml,csv,sql})."
+            " The directory's basename is the migration namespace.",
+        )
+
+        generate_parser = subparsers.add_parser(
+            "generate",
+            parents=[common],
+            help="Create a new migration file and exit.",
+        )
+        generate_parser.add_argument(
+            "name",
+            metavar="NAME",
+            help="Migration name, optionally with a .py/.xml/.csv/.sql"
+            " extension (defaults to .py).",
+        )
+
+        apply_parser = subparsers.add_parser(
+            "apply",
+            parents=[common],
+            help="Apply pending shoehorns to the database.",
+            epilog="Unrecognised arguments are passed through to Odoo's config"
+            " parser (e.g. -c /etc/odoo/odoo.conf, -d mydb).",
+        )
+        apply_parser.add_argument(
+            "--shoehorn-namespace",
+            metavar="NAME",
+            help="Override the migration namespace (defaults to the basename"
+            " of --shoehorn-path). Pinning it makes the applied log immune"
+            " to directory renames.",
+        )
+        apply_parser.add_argument(
+            "--neutralize",
+            action="store_true",
+            help="neutralize the database as the final step",
+        )
+
+        args, odoo_args = parser.parse_known_args(cmdargs)
+
+        if args.command == "generate":
+            # CLI output, not debugging
+            print(generate(args.shoehorn_path, args.name))  # pylint: disable=print-used
+            return
+
+        # pass anything else to odoo to parse
+        odoo.tools.config.parse_config(odoo_args)
+
+        if args.command == "apply":
+            migrate(args.shoehorn_path, namespace_override=args.shoehorn_namespace)
+
+            if args.neutralize:
+                input("Press Enter to continue with odoo neutralize...")
+                odoo.cli.neutralize.Neutralize().run([])

--- a/shoehorn/cli/shoehorn.py
+++ b/shoehorn/cli/shoehorn.py
@@ -23,20 +23,17 @@ class Shoehorn(Command):
         )
         subparsers = parser.add_subparsers(dest="command", required=True)
 
-        common = argparse.ArgumentParser(add_help=False)
-        common.add_argument(
-            "--shoehorn-path",
-            required=True,
-            metavar="DIR",
+        path_arg = dict(
+            metavar="PATH",
             help="Directory of shoehorn files (YYYYMMDDHHMMSS_name.{py,xml,csv,sql})."
             " The directory's basename is the migration namespace.",
         )
 
         generate_parser = subparsers.add_parser(
             "generate",
-            parents=[common],
             help="Create a new migration file and exit.",
         )
+        generate_parser.add_argument("path", **path_arg)
         generate_parser.add_argument(
             "name",
             metavar="NAME",
@@ -46,11 +43,11 @@ class Shoehorn(Command):
 
         apply_parser = subparsers.add_parser(
             "apply",
-            parents=[common],
             help="Apply pending shoehorns to the database.",
             epilog="Unrecognised arguments are passed through to Odoo's config"
             " parser (e.g. -c /etc/odoo/odoo.conf, -d mydb).",
         )
+        apply_parser.add_argument("path", **path_arg)
         apply_parser.add_argument(
             "--shoehorn-namespace",
             metavar="NAME",
@@ -68,14 +65,14 @@ class Shoehorn(Command):
 
         if args.command == "generate":
             # CLI output, not debugging
-            print(generate(args.shoehorn_path, args.name))  # pylint: disable=print-used
+            print(generate(args.path, args.name))  # pylint: disable=print-used
             return
 
         # pass anything else to odoo to parse
         odoo.tools.config.parse_config(odoo_args)
 
         if args.command == "apply":
-            migrate(args.shoehorn_path, namespace_override=args.shoehorn_namespace)
+            migrate(args.path, namespace_override=args.shoehorn_namespace)
 
             if args.neutralize:
                 input("Press Enter to continue with odoo neutralize...")

--- a/shoehorn/generate.py
+++ b/shoehorn/generate.py
@@ -1,0 +1,35 @@
+"""
+Generating new migration files (`odoo shoehorn generate`).
+
+The naming convention (FILENAME_RE etc.) is defined in migration.py.
+"""
+
+import datetime
+import os
+import re
+
+from .migration import EXTENSIONS, FILENAME_RE, TIMESTAMP_FORMAT
+
+TEMPLATES = {
+    "py": "def up(env):\n    pass\n",
+    "xml": '<?xml version="1.0" encoding="UTF-8" ?>\n<odoo>\n</odoo>\n',
+    "csv": "",
+    "sql": "",
+}
+
+
+def generate(directory, name):
+    """Create a new migration file in `directory` and return its path."""
+    base, ext = os.path.splitext(name)
+    ext = (ext.lstrip(".") or "py").lower()
+    if ext not in EXTENSIONS:
+        raise ValueError(f"Migrations can't have a .{ext} extension.")
+    base = re.sub(r"[\s-]+", "_", base.strip().lower())
+    version = datetime.datetime.now().strftime(TIMESTAMP_FORMAT)
+    filename = f"{version}_{base}.{ext}"
+    if not FILENAME_RE.match(filename):
+        raise ValueError(f"'{name}' does not make a valid migration name.")
+    path = os.path.join(os.path.abspath(directory), filename)
+    with open(path, "x") as f:
+        f.write(TEMPLATES[ext])
+    return path

--- a/shoehorn/migration.py
+++ b/shoehorn/migration.py
@@ -1,0 +1,235 @@
+"""Discovering and applying migrations - see README.rst for the model."""
+
+import contextlib
+import inspect
+import json
+import logging
+import os
+import re
+import zlib
+
+import psycopg2
+
+import odoo
+from odoo.tools.convert import (
+    convert_csv_import,
+    convert_sql_import,
+    convert_xml_import,
+)
+
+try:
+    # Doodba images ship click-odoo; prefer its environment handling (user
+    # context, registry/connection teardown, cross-version compatibility).
+    from click_odoo import OdooEnvironment
+except ImportError:
+
+    @contextlib.contextmanager
+    def OdooEnvironment(database):
+        """Minimal stand-in for click_odoo.OdooEnvironment."""
+        registry = odoo.modules.registry.Registry(database)
+        try:
+            with registry.cursor() as cr:
+                # cursor context manager commits on success, rolls back on error
+                yield odoo.api.Environment(cr, odoo.SUPERUSER_ID, {})
+        finally:
+            odoo.modules.registry.Registry.delete(database)
+            odoo.sql_db.close_db(database)
+
+
+_logger = logging.getLogger("shoehorn")
+
+# ir.model.data namespace for records created by data migrations, per
+# migration namespace: __shoehorn_<namespace>__. Unshared so directories
+# can't silently clobber each other's records by reusing an id;
+# cross-namespace references must be fully qualified.
+MODULE_FORMAT = "__shoehorn_{}__"
+# Applied log parameter, per namespace: shoehorn.applied.<namespace>
+STATE_PARAM_PREFIX = "shoehorn.applied"
+# Constant, deterministic key for the per-database advisory lock
+ADVISORY_LOCK_KEY = zlib.crc32(b"shoehorn")
+EXTENSIONS = ("py", "xml", "csv", "sql")
+TIMESTAMP_FORMAT = "%Y%m%d%H%M%S"
+FILENAME_RE = re.compile(
+    r"^(?P<version>\d{14})"
+    r"_(?P<name>[a-z0-9][a-z0-9._]*)"
+    r"\.(?P<ext>py|xml|csv|sql)$"
+)
+# No dots or dashes: the namespace is embedded in the ir.model.data module
+# name, and xmlids split on the first dot.
+NAMESPACE_RE = re.compile(r"^[a-z0-9][a-z0-9_]*$")
+
+
+def namespace(directory, override=None):
+    """
+    The migration namespace: `override` if given, else `directory`'s
+    basename. Each namespace has its own applied log, so e.g. ./bootstrap
+    and a one-off ./fixup_t12345 are tracked independently. Renaming a
+    directory renames the namespace - the new name starts from an empty
+    log - unless the namespace is pinned with `override`.
+    """
+    name = override or os.path.basename(os.path.normpath(os.path.abspath(directory)))
+    if not NAMESPACE_RE.match(name):
+        raise ValueError(
+            f"'{name}' is not a valid migration namespace;"
+            " it must match [a-z0-9][a-z0-9_]*."
+        )
+    return name
+
+
+def migrations(directory):
+    """
+    Sorted (version, name, ext, path) tuples for the migration files in
+    `directory` (top level only). Files with migration extensions must match
+    the naming convention; anything else is ignored.
+    """
+    directory = os.path.abspath(directory)
+    found = []
+    for entry in sorted(os.scandir(directory), key=lambda e: e.name):
+        if not entry.is_file():
+            continue
+        ext = os.path.splitext(entry.name)[1].lower().lstrip(".")
+        if ext not in EXTENSIONS:
+            continue
+        match = FILENAME_RE.match(entry.name)
+        if not match:
+            raise ValueError(
+                f"'{entry.name}' does not match the migration naming convention"
+                " YYYYMMDDHHMMSS_name.{py,xml,csv,sql}."
+            )
+        found.append((match["version"], match["name"], match["ext"], entry.path))
+
+    versions = [version for version, _, _, _ in found]
+    duplicates = {v for v in versions if versions.count(v) > 1}
+    if duplicates:
+        raise ValueError(
+            "Duplicate migration timestamps: " + ", ".join(sorted(duplicates))
+        )
+    return found
+
+
+def _apply_python(env, path, **context):
+    with open(path, "rb") as f:
+        code = f.read()
+    scope = {"__name__": "shoehorn.migration", "__file__": path}
+    exec(compile(code, path, "exec"), scope)
+    up = scope.get("up")
+    if not callable(up):
+        raise ValueError(f"Migration '{os.path.basename(path)}' must define up(env).")
+    # Context is passed as keyword arguments, filtered to what up() declares:
+    # up(env), up(env, module=...), and up(env, **kwargs) all work.
+    params = inspect.signature(up).parameters
+    if not any(p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values()):
+        context = {k: v for k, v in context.items() if k in params}
+    up(env, **context)
+
+
+def _apply_data(env, module, path, name, ext):
+    idref = {}
+    if ext == "csv":
+        # convert_csv_import derives the model from the file name, so pass
+        # the name part without the timestamp prefix
+        with open(path, "rb") as f:
+            content = f.read()
+        convert_csv_import(env, module, f"{name}.csv", content, idref, "init", True)
+    elif ext == "sql":
+        with open(path, "rb") as f:
+            convert_sql_import(env, f)
+    else:
+        # convert_xml_import accepts a path; file objects must have a .name
+        convert_xml_import(env, module, path, idref, "init", True)
+
+
+def _db_name():
+    db_name = odoo.tools.config.get("db_name")
+    if isinstance(db_name, (list, tuple)):
+        db_name = db_name[0]
+    return db_name
+
+
+@contextlib.contextmanager
+def _advisory_lock(db_name):
+    """
+    Hold a session-level Postgres advisory lock for the duration of the run
+    so concurrent invocations can't double-apply migrations; like Rails, a
+    second runner fails fast rather than queueing.
+
+    A dedicated psycopg2 connection is required: each migration's environment
+    closes Odoo's connection pool on teardown, which would release a lock
+    held on a pooled connection. Advisory lock keys are scoped per database,
+    so different databases migrate concurrently without contention.
+    """
+    _, connection_info = odoo.sql_db.connection_info_for(db_name)
+    connection = psycopg2.connect(**connection_info)
+    try:
+        # no transaction needed for a session-level lock, and autocommit
+        # avoids sitting idle-in-transaction for the whole run
+        connection.autocommit = True
+        cursor = connection.cursor()
+        cursor.execute("SELECT pg_try_advisory_lock(%s)", (ADVISORY_LOCK_KEY,))
+        if not cursor.fetchone()[0]:
+            raise RuntimeError(
+                f"Another shoehorn run is already migrating {db_name}"
+                " (advisory lock held)."
+            )
+        yield
+    finally:
+        # disconnecting releases the session-level lock
+        connection.close()
+
+
+def migrate(directory, namespace_override=None):
+    """Apply the directory's pending migrations to the database."""
+    found = migrations(directory)
+    ns = namespace(directory, namespace_override)
+    state_param = f"{STATE_PARAM_PREFIX}.{ns}"
+    module = MODULE_FORMAT.format(ns)
+    db_name = _db_name()
+
+    # One lock per database, not per namespace: migrations from different
+    # directories touch the same modules and records.
+    with _advisory_lock(db_name):
+        # The applied log lives in the target database itself, so a fresh
+        # database always starts from zero and re-running the command applies
+        # only what is pending, regardless of which host runs it.
+        with OdooEnvironment(database=db_name) as env:
+            applied = json.loads(
+                env["ir.config_parameter"].get_param(state_param) or "[]"
+            )
+        done = {entry["version"] for entry in applied}
+        pending = [m for m in found if m[0] not in done]
+        _logger.info(
+            f"{len(found)} migrations in {os.path.abspath(directory)}"
+            f" (namespace '{ns}');"
+            f" {len(found) - len(pending)} applied, {len(pending)} pending."
+        )
+
+        # Built-in initial step: refresh the module list on every invocation
+        with OdooEnvironment(database=db_name) as env:
+            _logger.info("Updating module list.")
+            env["ir.module.module"].update_list()
+
+        for index, (version, name, ext, path) in enumerate(pending, start=1):
+            filename = os.path.basename(path)
+            _logger.info(f"[{index}/{len(pending)}] {filename}")
+            try:
+                # Each migration gets a fresh registry, env and transaction;
+                # commit on success and rollback on error are handled by
+                # OdooEnvironment.
+                with OdooEnvironment(database=db_name) as env:
+                    if ext == "py":
+                        _apply_python(env, path, namespace=ns, module=module)
+                    else:
+                        _apply_data(env, module, path, name, ext)
+                    # Record in the same transaction as the migration: the
+                    # log entry exists if and only if the migration committed.
+                    applied.append({"version": version, "name": name})
+                    env["ir.config_parameter"].set_param(
+                        state_param, json.dumps(applied)
+                    )
+            except Exception:
+                _logger.critical(
+                    f"Migration '{filename}' failed. Transaction rolled back."
+                )
+                raise
+
+    _logger.info("Database is up to date.")

--- a/shoehorn/pyproject.toml
+++ b/shoehorn/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["whool"]
+build-backend = "whool.buildapi"

--- a/shoehorn/security/ir.model.access.csv
+++ b/shoehorn/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_shoehorn_generate_wizard,shoehorn.generate.wizard,model_shoehorn_generate_wizard,base.group_system,1,1,1,1

--- a/shoehorn/tools/__init__.py
+++ b/shoehorn/tools/__init__.py
@@ -1,0 +1,5 @@
+from .modules import (
+    install_addons_yaml,
+    install_modules,
+    install_private_modules,
+)

--- a/shoehorn/tools/modules.py
+++ b/shoehorn/tools/modules.py
@@ -1,0 +1,58 @@
+"""Module-installation helpers for .py migrations."""
+
+import logging
+import os
+
+import yaml
+
+_logger = logging.getLogger("shoehorn")
+
+
+def install_modules(env, modules):
+    """Install modules by technical name; raise if any are unavailable."""
+    found = env["ir.module.module"].search([("name", "in", list(modules))])
+    missing = sorted(set(modules) - set(found.mapped("name")))
+    for module in missing:
+        _logger.critical(f"  Could not find module {module}")
+    needs_action = found.filtered(lambda m: m.state != "installed")
+    if needs_action:
+        needs_action.button_immediate_install()
+    # Re-search: button_immediate_install resets the registry
+    still_not = env["ir.module.module"].search(
+        [("name", "in", list(modules)), ("state", "!=", "installed")]
+    )
+    for module in still_not:
+        _logger.critical(f"  {module.name} not installed")
+    if missing or still_not:
+        raise RuntimeError(
+            "Modules missing or not installed: "
+            + ", ".join(missing + still_not.mapped("name"))
+        )
+
+
+def install_addons_yaml(env, path="/opt/odoo/custom/src/addons.yaml"):
+    """Install every explicitly named addon from a doodba addons.yaml."""
+    _logger.info(f"  Installing modules from {path}")
+    with open(path) as f:
+        addons_yaml = yaml.safe_load(f)
+    for repo, repo_addons in addons_yaml.items():
+        addons = [a for a in repo_addons if a != "*"]
+        if not addons:
+            continue
+        _logger.info(f"  Working on {repo}")
+        install_modules(env, addons)
+
+
+def install_private_modules(env, path="/opt/odoo/custom/src/private"):
+    """Install every module found in the private addons directory."""
+    _logger.info(f"  Installing modules from {path}")
+    private_addons = [
+        f.name
+        for f in os.scandir(path)
+        if (
+            f.is_dir()
+            and not f.name.startswith(".")
+            and os.path.exists(os.path.join(f.path, "__manifest__.py"))
+        )
+    ]
+    install_modules(env, private_addons)

--- a/shoehorn/views/generate_wizard_views.xml
+++ b/shoehorn/views/generate_wizard_views.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <record id="shoehorn_generate_wizard_form" model="ir.ui.view">
+        <field name="name">shoehorn.generate.wizard.form</field>
+        <field name="model">shoehorn.generate.wizard</field>
+        <field name="arch" type="xml">
+            <form string="Generate shoehorn migration">
+                <group>
+                    <field
+                        name="path"
+                        placeholder="/opt/odoo/custom/src/private/.../bootstrap"
+                    />
+                    <field name="file_type" />
+                    <field name="name" placeholder="add_a_thing" />
+                    <field name="generated_path" invisible="not generated_path" />
+                </group>
+                <footer>
+                    <button
+                        name="action_generate"
+                        type="object"
+                        string="Generate"
+                        class="btn-primary"
+                    />
+                    <button special="cancel" string="Close" class="btn-secondary" />
+                </footer>
+            </form>
+        </field>
+    </record>
+
+    <record id="shoehorn_generate_wizard_action" model="ir.actions.act_window">
+        <field name="name">Generate shoehorn migration</field>
+        <field name="res_model">shoehorn.generate.wizard</field>
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+    </record>
+
+    <menuitem
+        id="menu_shoehorn_generate"
+        name="Generate shoehorn migration"
+        parent="base.menu_custom"
+        action="shoehorn_generate_wizard_action"
+        sequence="100"
+    />
+</odoo>

--- a/shoehorn/wizards/__init__.py
+++ b/shoehorn/wizards/__init__.py
@@ -1,0 +1,1 @@
+from . import generate_wizard

--- a/shoehorn/wizards/generate_wizard.py
+++ b/shoehorn/wizards/generate_wizard.py
@@ -1,0 +1,54 @@
+"""UI front-end for `odoo shoehorn generate` (see ../generate.py).
+
+Available only when the module is installed; the CLI needs neither this model
+nor a database. The wizard does no work of its own - it hands a directory and
+a `name.ext` to generate(), so naming, validation and templates stay identical
+to the CLI.
+"""
+
+from odoo import fields, models
+from odoo.exceptions import UserError
+
+from ..generate import generate
+from ..migration import EXTENSIONS
+
+
+class ShoehornGenerateWizard(models.TransientModel):
+    _name = "shoehorn.generate.wizard"
+    _description = "Generate a shoehorn migration file"
+
+    path = fields.Char(
+        string="Directory",
+        required=True,
+        help="Directory of shoehorn files, on the Odoo server's filesystem."
+        " Its basename is the migration namespace.",
+    )
+    file_type = fields.Selection(
+        selection=[(ext, ext) for ext in EXTENSIONS],
+        required=True,
+        default="py",
+    )
+    name = fields.Char(
+        required=True,
+        help="Migration name (the part after the timestamp). For .csv it must"
+        " be the target model name, e.g. res.partner.",
+    )
+    generated_path = fields.Char(string="Generated file", readonly=True)
+
+    def action_generate(self):
+        self.ensure_one()
+        # generate() does all the filtering/validation; let it own the rules
+        # and surface its complaints to the user rather than re-implementing.
+        try:
+            path = generate(self.path, f"{self.name}.{self.file_type}")
+        except (ValueError, OSError) as exc:
+            raise UserError(str(exc)) from exc
+        self.generated_path = path
+        return {
+            "type": "ir.actions.act_window",
+            "name": self.env._("Migration generated"),
+            "res_model": self._name,
+            "res_id": self.id,
+            "view_mode": "form",
+            "target": "new",
+        }


### PR DESCRIPTION
Shoehorn is born from various attempts to create database bootstrap functions for our (Glo's) Odoo projects.

We've tried several things over the years with problems:
- bootstrap modules: these become a pain in the ass if you declare your dependencies. If you have a wizard to "apply" you end up with a deadmodule that's dangerous to keep around.
- click-odoo scripts: these become problematic with the registry needing to be restarted, so you end up with several scripts to run back to back.
- standalone scripts: structure-less
- manual: *barf*
- `camptocamp/marabunta` is powerful, but not what we're looking for. I'd rather use Ansible than something attempting to be Ansible.
- ansible: we'd need to write Odoo modules. Not interested in doing that.

The key benefit in being an Odoo module:
- You can ensure that the version of the module supports a given version of Odoo without lots of hacks/workarounds.

The negative is that you potentially have multiple versions.

Lets see how this works out..

Extra features over rails migrations and marabunta:
* Multiple namespaces are supported, i.e. this may be used for both bootstrapping a database or complex multistep fix ups

**Dependencies:**
- N/A

**ARL (Associated Risk Level):**
- [ ] Low
- [ ] Medium
- [ ] High

**Type of change:**
- [ ] Forwardport / Backport
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

