### PR TITLE
[FEAT] delivery_carrier_block_validate Module

### DIFF
--- a/delivery_carrier_block_validate/README.rst
+++ b/delivery_carrier_block_validate/README.rst
@@ -1,0 +1,2 @@
+delivery_carrier_block_validate
+===============================

--- a/delivery_carrier_block_validate/__init__.py
+++ b/delivery_carrier_block_validate/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/delivery_carrier_block_validate/__manifest__.py
+++ b/delivery_carrier_block_validate/__manifest__.py
@@ -1,0 +1,11 @@
+{
+    "name": "delivery_carrier_block_validate",
+    "author": "Glo Networks",
+    "version": "19.0.1.0.0",
+    "website": "https://github.com/GlodoUK/odoo-addons",
+    "depends": ["stock_delivery"],
+    "data": [
+        "views/delivery_carrier_views.xml",
+    ],
+    "license": "Other proprietary",
+}

--- a/delivery_carrier_block_validate/models/__init__.py
+++ b/delivery_carrier_block_validate/models/__init__.py
@@ -1,0 +1,2 @@
+from . import delivery_carrier
+from . import stock_picking

--- a/delivery_carrier_block_validate/models/delivery_carrier.py
+++ b/delivery_carrier_block_validate/models/delivery_carrier.py
@@ -1,0 +1,7 @@
+from odoo import fields, models
+
+
+class DeliveryCarrier(models.Model):
+    _inherit = "delivery.carrier"
+
+    block_validate = fields.Boolean()

--- a/delivery_carrier_block_validate/models/stock_picking.py
+++ b/delivery_carrier_block_validate/models/stock_picking.py
@@ -1,0 +1,25 @@
+from odoo import models
+from odoo.exceptions import UserError
+
+
+class StockPicking(models.Model):
+    _inherit = "stock.picking"
+
+    def button_validate(self):
+        block_picking_ids = self.filtered(
+            lambda p: p.carrier_id.block_validate and p.state != "done"
+        )
+
+        if block_picking_ids:
+            block_picking_names = "\n".join(
+                f"{picking.name} : {picking.carrier_id.name}"
+                for picking in block_picking_ids
+            )
+            raise UserError(
+                self.env._(
+                    "Validation is blocked by the delivery method on the following transfers:\n%(pickings)s",  # noqa: E501
+                    pickings=block_picking_names,
+                )
+            )
+
+        return super().button_validate()

--- a/delivery_carrier_block_validate/pyproject.toml
+++ b/delivery_carrier_block_validate/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["whool"]
+build-backend = "whool.buildapi"

--- a/delivery_carrier_block_validate/views/delivery_carrier_views.xml
+++ b/delivery_carrier_block_validate/views/delivery_carrier_views.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <record id="view_delivery_carrier_form" model="ir.ui.view">
+        <field name="name">delivery.carrier.form</field>
+        <field name="model">delivery.carrier</field>
+        <field name="inherit_id" ref="delivery.view_delivery_carrier_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='product_id']" position="after">
+                <field name="block_validate" />
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
**Dependencies:**
- N/A

**ARL (Associated Risk Level):**
- [X] Low
- [ ] Medium
- [ ] High

**Type of change:**
- [ ] Forwardport / Backport
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/GlodoUK/codesmith/odoo-addons/pr/311"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787933118&installation_model_id=426334&pr_number=311&repository=GlodoUK%2Fodoo-addons&return_to=https%3A%2F%2Fgithub.com%2FGlodoUK%2Fodoo-addons%2Fpull%2F311&signature=9e16e29db7009b9816c7827644d8ba552e07eaead922e0a923f5d29340bac991"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->