### PR TITLE
[19.0][ADD] base_search_rank and product search siblings

### DIFF
--- a/base_search_rank/README.rst
+++ b/base_search_rank/README.rst
@@ -1,0 +1,123 @@
+================
+base_search_rank
+================
+
+Ranked substring + fuzzy searching as a custom field type, built on pg_trgm
+word similarity.
+
+The problem: searching ``967`` should return both ``sku=967`` and
+``sku=aaa967bb``, with the exact match first — and ``candel`` should still
+find candles. Plain ``ilike`` gets the recall but not the ranking or the
+misspellings; this module provides both.
+
+One ``SearchRank`` field is both the searchable document and the search
+driver: it computes its own content from the declared ``sources``, and
+supplies the behaviour through the ORM's own per-field hooks: domain
+conditions on it expand to substring OR fuzzy matching
+(``Field.determine_domain``), and its ``rank`` property renders a relevance
+expression for ordering (``Field.property_to_sql``). No mixin, no model
+overrides, no manual compute to drift out of sync; all configuration is
+code.
+
+This is deliberately not OCA's ``base_search_fuzzy``: that module only adds
+a whole-string ``%`` similarity operator (which misses short codes against
+long texts entirely) with no ranking, configures its indexes through DB
+records, and its expression monkey-patch has no target in Odoo 19.
+
+Usage
+=====
+
+Declare what is searchable::
+
+    from odoo.addons.base_search_rank.fields import SearchRank
+
+    class ProductProduct(models.Model):
+        _inherit = "product.product"
+
+        search_rank = SearchRank(
+            sources=("=default_code", "barcode", "product_tmpl_id.name"),
+        )
+
+The field computes its own document from ``sources`` (dotted paths allowed,
+concatenated in declaration order; translated fields contribute every
+installed language) and recomputes when they change. ``store=True`` and
+``index='trigram'`` are forced — Odoo 19 natively builds the
+``unaccent(...) gin_trgm_ops`` GIN index, which serves both match arms.
+
+A leading ``=`` (mirroring Odoo's ``=like``) marks an exact source: its
+whole-value (case/accent-insensitive) match with the term outranks any
+similarity score — typically the code/SKU field. Because an exact source
+is part of the document like any other source, its matches are always
+findable; there is no separate list to drift out of sync. There is also
+deliberately no custom-compute option — that split is exactly where the
+document and the ranking would drift apart; subclass and override
+``_compute_from_sources`` for special document needs.
+
+Then::
+
+    from odoo.addons.base_search_rank.utils import search_ranked
+
+    search_ranked(env["product.product"], "967", limit=20)
+
+returns records matched by substring *or* fuzzy word similarity, ordered
+best-first: whole-value ``default_code`` matches score 2.0, above any
+``word_similarity()`` score against the document.
+
+The field composes with the standard ORM everywhere:
+
+- ``[('search_rank', 'ilike', term)]`` is a normal domain condition, usable
+  anywhere — including dropping ``<field name="search_rank"/>`` into a
+  search view for fuzzy matching from the search bar (matching only; a
+  search view cannot inject ordering).
+- ``order='search_rank.rank desc'`` ranks any search() by relevance,
+  whenever the term is in context as ``search_rank_term``
+  (``search_ranked()`` arranges both).
+
+For UI integration, inherit ``base_search_rank.mixin`` alongside the
+model::
+
+    class ProductProduct(models.Model):
+        _name = "product.product"
+        _inherit = ["product.product", "base_search_rank.mixin"]
+
+It wires two things, both inert until used:
+
+- ``name_search`` returns ranked + fuzzy suggestions when opted in per m2o
+  field, per view, via the field's ``context`` attribute (the same plumbing
+  core uses for ``partner_id`` on product fields)::
+
+      <field name="product_id" context="{'search_rank_enable': True}"/>
+
+  Everything else — including programmatic callers using ``name_search`` as
+  a conservative matcher, where fuzzy must not turn "not found" into a
+  plausible wrong record — stays stock. Cross-model domain resolution
+  (``('product_id', 'ilike', 'foo')`` on other models) does not pass
+  through ``name_search`` at all, so the blast radius is opted-in dropdowns
+  and direct callers only.
+
+- ``_search`` orders by relevance whenever the domain contains a condition
+  on a SearchRank field (e.g. a search-view facet on it); the caller's
+  order becomes the tiebreak within equal ranks. Other searches are
+  untouched.
+
+Notes
+=====
+
+- ``=``-marked sources must be direct stored fields on the model (the rank
+  SQL is built against the model's own table, without joins). The boost
+  compares the term against the live column (whole-value,
+  case/accent-insensitive), not the document.
+- The fuzzy cutoff is a per-field parameter (``SearchRank(sources=...,
+  threshold=0.5)``, default 0.4), applied per-transaction via
+  ``set_config``; the postgres default of 0.6 rejects common misspellings
+  ("candel" -> "candle" scores 0.571), while lower values admit more noise
+  — which ranking keeps at the bottom.
+- ``pre_init_hook`` creates the pg_trgm extension (or fails install with
+  instructions if it lacks permission).
+- Reading the field yields the document text (handy for debugging what is
+  actually searchable).
+- Always order by ``search_rank.rank``; ordering by the bare field name
+  sorts by document text. Without ``search_rank_term`` in context the rank
+  renders as a constant. Neither is valid in ``_read_group`` ordering.
+- The field's matching replaces core ``ilike`` SQL for conditions on it
+  (substring semantics are preserved; both sides are unaccented like core).

--- a/base_search_rank/__init__.py
+++ b/base_search_rank/__init__.py
@@ -1,0 +1,4 @@
+from . import fields
+from . import models
+from . import utils
+from .hooks import pre_init_hook

--- a/base_search_rank/__manifest__.py
+++ b/base_search_rank/__manifest__.py
@@ -1,0 +1,12 @@
+{
+    "name": "base_search_rank",
+    "summary": "Ranked substring + fuzzy searching via pg_trgm word similarity",
+    "author": "Glo Networks",
+    "website": "https://github.com/GlodoUK/odoo-addons",
+    "category": "Hidden",
+    "development_status": "Alpha",
+    "version": "19.0.1.0.0",
+    "depends": ["base"],
+    "pre_init_hook": "pre_init_hook",
+    "license": "Other proprietary",
+}

--- a/base_search_rank/fields.py
+++ b/base_search_rank/fields.py
@@ -1,0 +1,226 @@
+from odoo import fields
+from odoo.fields import Domain
+from odoo.tools import SQL
+
+
+def apply_word_similarity_threshold(env, threshold):
+    """Set the pg_trgm fuzzy-match cutoff, scoped to the current transaction."""
+    env.cr.execute(
+        "SELECT set_config('pg_trgm.word_similarity_threshold', %s, true)",
+        [str(threshold)],
+    )
+
+
+class SearchRank(fields.Text):
+    """Stored searchable document with ranked substring + fuzzy search.
+
+    One field is document and search driver. Declare what is searchable and
+    the field computes the document itself::
+
+        search_rank = SearchRank(
+            sources=("=default_code", "barcode", "product_tmpl_id.name"),
+        )
+
+    ``sources`` are field names (dotted paths allowed), concatenated in
+    declaration order; translated fields contribute every installed
+    language. A leading ``=`` (mirroring Odoo's ``=like``) marks an exact
+    source: its whole-value (case/accent-insensitive) match with the term
+    outranks any similarity score — typically the code/SKU field. Exact
+    sources are part of the document like any other, which is what
+    guarantees their matches are found in the first place (matching only
+    sees the document; ranking only reorders what matching found). They
+    must be direct stored fields (the rank SQL is built without joins).
+
+    There is deliberately no custom compute option — the document and the
+    ranking must not drift apart. A model with genuinely special document
+    needs should subclass and override ``_compute_from_sources``.
+
+    ``store=True`` and ``index='trigram'`` are forced (Odoo builds the
+    ``unaccent(...) gin_trgm_ops`` GIN index natively), and the field drives
+    search through the ORM's per-field hooks:
+
+    - **Matching**: any text condition on the field — ``('search_rank',
+      'ilike', term)``, or the field dropped into a search view — expands
+      to substring (``ILIKE``, so an embedded "967" always hits) OR pg_trgm
+      word similarity (so misspellings hit).
+    - **Ranking**: the ``rank`` property renders a relevance expression, so
+      ``order='search_rank.rank desc'`` (with the term in context as
+      ``search_rank_term``) sorts best-first through the standard ordering
+      path: whole-value equality on the ``=``-marked sources scores 2.0,
+      above any ``word_similarity()`` score. Without a
+      term in context it renders 0.0 and orders nothing. Ordering by the
+      bare field name is the document text, i.e. meaningless — always order
+      by ``.rank``. Not valid as a read_group order.
+
+    ``utils.search_ranked(model, term)`` bundles both for the common case.
+
+    The other attribute is ``threshold`` — the fuzzy cutoff, see below.
+    """
+
+    type = "text"
+
+    sources = ()
+    # pg_trgm.word_similarity_threshold for the fuzzy match arm. The
+    # postgres default (0.6) rejects classic misspellings such as
+    # "candel" -> "candle" (0.571); 0.4 accepts them while ranking keeps
+    # the noise it lets in at the bottom.
+    threshold = 0.4
+
+    # truthy so domain optimization routes conditions to determine_domain()
+    search = True
+
+    def _setup_attrs__(self, model_class, name):  # noqa: PLW3201
+        res = super()._setup_attrs__(model_class, name)
+        self.store = True
+        if not self.index:
+            self.index = "trigram"
+        assert not isinstance(self.sources, str) and self.sources, (
+            f"SearchRank field {self} requires sources=(field names,)"
+        )
+        assert not getattr(self, "exact", None), (
+            f"SearchRank field {self}: exact= has been merged into sources;"
+            " mark exact sources with a leading '=', e.g. '=default_code'"
+        )
+        self._source_paths = tuple(s.lstrip("=") for s in self.sources)
+        self._exact_fields = tuple(s[1:] for s in self.sources if s.startswith("="))
+        assert all(fname.count(".") <= 1 for fname in self._exact_fields), (
+            f"SearchRank field {self}: exact sources must be direct stored"
+            " fields or a single one2many hop (e.g."
+            " '=product_variant_ids.default_code')"
+        )
+        assert not self.compute, (
+            f"SearchRank field {self} computes itself from sources;"
+            " subclass and override _compute_from_sources for custom needs"
+        )
+        self.compute = self._compute_from_sources
+        self._depends = self._source_paths
+        return res
+
+    def _compute_from_sources(self, records):
+        lang_codes = [code for code, _name in records.env["res.lang"].get_installed()]
+        for record in records:
+            values = []
+            for path in self._source_paths:
+                target, fname = record, path
+                while "." in fname:
+                    relation, fname = fname.split(".", 1)
+                    target = target[relation]
+                field = target._fields[fname]
+                if field.translate:
+                    values += [
+                        value
+                        for code in lang_codes
+                        for value in target.with_context(lang=code).mapped(fname)
+                        if value
+                    ]
+                else:
+                    values += [str(value) for value in target.mapped(fname) if value]
+            record[self.name] = " ".join(dict.fromkeys(values)) or False
+
+    def determine_domain(self, records, operator, value):
+        # `search` intercepts every condition on this field, so whatever we
+        # return must not mention the field by name (it would recurse back
+        # here); both match arms are emitted as custom SQL against the
+        # column instead.
+        if operator not in ("ilike", "like", "=ilike", "=like", "="):
+            return NotImplemented
+        fname = self.name
+        if not isinstance(value, str) or not value.strip():
+            # nullness checks, e.g. ('search_rank', '=', False)
+            return Domain.custom(
+                to_sql=lambda model, alias, query: SQL(
+                    "%s IS NULL", model._field_to_sql(alias, fname, query)
+                ),
+                predicate=lambda record: not record[fname],
+            )
+        term = value.strip()
+        apply_word_similarity_threshold(records.env, self.threshold)
+
+        def match_to_sql(model, alias, query):
+            unaccent = model.env.registry.unaccent
+            sql_col = unaccent(model._field_to_sql(alias, fname, query))
+            return SQL(
+                "(%s ILIKE %s OR %s <%% %s)",
+                sql_col,
+                unaccent(SQL("%s", f"%{term}%")),
+                unaccent(SQL("%s", term)),
+                sql_col,
+            )
+
+        return Domain.custom(
+            to_sql=match_to_sql,
+            # Python-side evaluation (record rules, filtered_domain) has no
+            # word_similarity; approximate with the substring arm, so
+            # fuzzy-only matches are dropped rather than crashing.
+            predicate=lambda record: term.lower() in (record[fname] or "").lower(),
+        )
+
+    def property_to_sql(self, field_sql, property_name, model, alias, query):
+        # Renders `search_rank.rank` as a relevance score, which makes
+        # order='search_rank.rank desc' work through the standard ordering
+        # path. ORDER BY has no value channel of its own, so the term
+        # travels in context.
+        if property_name != "rank":
+            return super().property_to_sql(
+                field_sql, property_name, model, alias, query
+            )
+        term = (model.env.context.get("search_rank_term") or "").strip()
+        if not term:
+            return SQL("0.0")
+        unaccent = model.env.registry.unaccent
+        sql_term = unaccent(SQL("%s", term))
+        scores = []
+        for fname in self._exact_fields:
+            if "." in fname:
+                scores.append(
+                    self._exact_score_one2many_sql(model, alias, fname, sql_term)
+                )
+                continue
+            sql_field = unaccent(model._field_to_sql(alias, fname))
+            scores.append(
+                SQL("(LOWER(%s) = LOWER(%s))::int * 2.0", sql_field, sql_term)
+            )
+        scores.append(
+            SQL("COALESCE(word_similarity(%s, %s), 0.0)", sql_term, unaccent(field_sql))
+        )
+        if len(scores) == 1:
+            return scores[0]
+        return SQL("GREATEST(%s)", SQL(", ").join(scores))
+
+    def _exact_score_one2many_sql(self, model, alias, path, sql_term):
+        # exact boost through a one2many hop, e.g.
+        # '=product_variant_ids.default_code' on product.template: boost
+        # when any (active) child record's field equals the term
+        rel_name, sub_name = path.split(".")
+        rel_field = model._fields[rel_name]
+        assert rel_field.type == "one2many" and rel_field.inverse_name, (
+            f"SearchRank field {self}: exact source {path!r} must traverse"
+            " a one2many with an inverse field"
+        )
+        comodel = model.env[rel_field.comodel_name]
+        sub_field = comodel._fields[sub_name]
+        assert sub_field.store and sub_field.column_type, (
+            f"SearchRank field {self}: exact source {path!r} must end on a"
+            " stored column"
+        )
+        unaccent = model.env.registry.unaccent
+        where = SQL(
+            "%s = %s AND LOWER(%s) = LOWER(%s)",
+            SQL.identifier("__search_rank", rel_field.inverse_name),
+            SQL.identifier(alias, "id"),
+            unaccent(SQL.identifier("__search_rank", sub_name)),
+            sql_term,
+        )
+        if comodel._active_name:
+            # mirror the document compute, which reads active children only
+            where = SQL(
+                "%s AND %s",
+                where,
+                SQL.identifier("__search_rank", comodel._active_name),
+            )
+        return SQL(
+            "EXISTS (SELECT 1 FROM %s AS %s WHERE %s)::int * 2.0",
+            SQL.identifier(comodel._table),
+            SQL.identifier("__search_rank"),
+            where,
+        )

--- a/base_search_rank/hooks.py
+++ b/base_search_rank/hooks.py
@@ -1,0 +1,28 @@
+import logging
+
+import psycopg2
+
+from odoo.exceptions import UserError
+
+_logger = logging.getLogger(__name__)
+
+
+def pre_init_hook(env):
+    env.cr.execute("SELECT 1 FROM pg_extension WHERE extname = 'pg_trgm'")
+    if env.cr.fetchone():
+        return
+    try:
+        env.cr.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm")
+    except psycopg2.Error as e:
+        raise UserError(
+            env._(
+                "base_search_rank requires the pg_trgm extension. Automatic "
+                "installation failed (usually a permissions issue); run "
+                '"CREATE EXTENSION pg_trgm;" as a database superuser and retry.'
+            )
+        ) from e
+    # has_trigram was snapshotted at registry init, before the extension
+    # existed; correct it so consumer modules installed in this same registry
+    # load still get their GIN indexes built by check_indexes().
+    env.registry.has_trigram = True
+    _logger.info("Created the pg_trgm extension")

--- a/base_search_rank/models/__init__.py
+++ b/base_search_rank/models/__init__.py
@@ -1,0 +1,1 @@
+from . import search_rank_ui_mixin

--- a/base_search_rank/models/search_rank_ui_mixin.py
+++ b/base_search_rank/models/search_rank_ui_mixin.py
@@ -1,0 +1,63 @@
+from odoo import api, models
+from odoo.fields import Domain
+
+from ..fields import SearchRank
+from ..utils import search_ranked
+
+
+class SearchRankUiMixin(models.AbstractModel):
+    """Opt-in UI wiring for models declaring a SearchRank field.
+
+    - ``name_search`` returns ranked + fuzzy suggestions when the caller
+      opts in via context — per m2o field, per view::
+
+          <field name="product_id" context="{'search_rank_enable': True}"/>
+
+      Everything else (including programmatic callers using name_search as
+      a conservative matcher, where fuzzy must not turn "not found" into a
+      plausible wrong record) stays stock. Assumes a single SearchRank
+      field on the model; override to disambiguate if there are several.
+
+    - ``_search`` orders by relevance whenever the domain contains a
+      condition on a SearchRank field (a search-view facet on it, or any
+      programmatic domain); other searches are untouched. Rank must lead
+      even over an explicit order — view archs hard-code default_order,
+      which the client sends indistinguishably from a user's column sort —
+      so the caller's order becomes the tiebreak within equal ranks.
+    """
+
+    _name = "base_search_rank.mixin"
+    _description = "Ranked Search UI Wiring"
+
+    @api.model
+    def name_search(self, name="", domain=None, operator="ilike", limit=100):
+        if (
+            name
+            and operator in ("ilike", "like", "=ilike", "=like")
+            and self.env.context.get("search_rank_enable")
+        ):
+            records = search_ranked(self, name, domain=domain, limit=limit)
+            return [(record.id, record.display_name) for record in records.sudo()]
+        return super().name_search(
+            name=name, domain=domain, operator=operator, limit=limit
+        )
+
+    @api.model
+    def _search(self, domain, offset=0, limit=None, order=None, **kwargs):
+        condition = next(
+            (
+                condition
+                for condition in Domain(domain).iter_conditions()
+                if isinstance(self._fields.get(condition.field_expr), SearchRank)
+                and condition.operator in ("ilike", "like", "=ilike", "=like", "=")
+                and isinstance(condition.value, str)
+                and condition.value.strip()
+            ),
+            None,
+        )
+        if condition:
+            self = self.with_context(search_rank_term=condition.value.strip())
+            order = f"{condition.field_expr}.rank desc, {order or self._order}"
+        return super()._search(
+            domain, offset=offset, limit=limit, order=order, **kwargs
+        )

--- a/base_search_rank/pyproject.toml
+++ b/base_search_rank/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["whool"]
+build-backend = "whool.buildapi"

--- a/base_search_rank/tests/__init__.py
+++ b/base_search_rank/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_search_rank

--- a/base_search_rank/tests/test_search_rank.py
+++ b/base_search_rank/tests/test_search_rank.py
@@ -1,0 +1,55 @@
+from odoo.tests.common import TransactionCase, tagged
+
+from odoo.addons.base_search_rank.fields import apply_word_similarity_threshold
+
+
+@tagged("post_install", "-at_install")
+class TestSearchRankPostgres(TransactionCase):
+    """Pin the postgres-level behaviour SearchRank's matching and ranking
+    rely on.
+
+    Consumer-facing behaviour (document content, translations, name_search
+    integration) is tested in the modules that declare SearchRank fields,
+    against their real fields.
+    """
+
+    def test_pg_trgm_installed(self):
+        self.env.cr.execute("SELECT 1 FROM pg_extension WHERE extname = 'pg_trgm'")
+        self.assertTrue(
+            self.env.cr.fetchone(),
+            "pg_trgm must be installed (pre_init_hook should have created it)",
+        )
+
+    def test_word_similarity_ranks_exact_first(self):
+        # the founding requirement: searching "967" must rank sku=967 above
+        # sku=aaa967bb, while both remain findable
+        self.env.cr.execute(
+            """
+            SELECT s, word_similarity('967', s)
+            FROM (VALUES ('967'), ('aaa967bb'), ('candle 900')) v(s)
+            ORDER BY 2 DESC
+            """
+        )
+        rows = self.env.cr.fetchall()
+        self.assertEqual(rows[0][0], "967")
+        self.assertEqual(rows[0][1], 1.0)
+        by_value = dict(rows)
+        self.assertLess(by_value["aaa967bb"], 1.0)
+
+    def test_threshold_admits_misspellings(self):
+        apply_word_similarity_threshold(self.env, 0.4)
+        self.env.cr.execute(
+            "SELECT %s::text <%% %s::text", ["candel", "scented candle large"]
+        )
+        self.assertTrue(
+            self.env.cr.fetchone()[0],
+            "candel -> candle must match at the configured threshold"
+            " (scores 0.571; the postgres default of 0.6 rejects it)",
+        )
+
+    def test_threshold_is_transaction_scoped(self):
+        apply_word_similarity_threshold(self.env, 0.4)
+        self.env.cr.execute(
+            "SELECT current_setting('pg_trgm.word_similarity_threshold')"
+        )
+        self.assertEqual(float(self.env.cr.fetchone()[0]), 0.4)

--- a/base_search_rank/utils.py
+++ b/base_search_rank/utils.py
@@ -1,0 +1,33 @@
+from odoo.fields import Domain
+
+
+def search_ranked(model, term, domain=None, limit=None, offset=0, field=None):
+    """search() ``model``, matched against ``term`` and ordered by relevance.
+
+    ``field`` names the model's SearchRank field; it may be omitted when the
+    model has exactly one. With a falsy/blank ``term`` this degrades to a
+    plain search of ``domain`` in the model's default order.
+    """
+    from .fields import SearchRank  # noqa: PLC0415 - avoid import cycle
+
+    term = (term or "").strip()
+    base = Domain(domain) if domain is not None else Domain.TRUE
+    if not term:
+        return model.search(base, limit=limit, offset=offset)
+    if field is None:
+        candidates = [
+            f.name for f in model._fields.values() if isinstance(f, SearchRank)
+        ]
+        if len(candidates) != 1:
+            raise ValueError(
+                f"{model._name} has {len(candidates)} SearchRank fields"
+                f" ({candidates}); pass field= explicitly"
+            )
+        field = candidates[0]
+    model = model.with_context(search_rank_term=term)
+    return model.search(
+        base & Domain(field, "ilike", term),
+        limit=limit,
+        offset=offset,
+        order=f"{field}.rank desc, {model._order}",
+    )

--- a/product_search_rank/README.rst
+++ b/product_search_rank/README.rst
@@ -1,0 +1,14 @@
+===================
+product_search_rank
+===================
+
+Ranked substring + fuzzy product searching, built on ``base_search_rank``.
+
+Adds a ``search_rank`` field to ``product.product`` and
+``product.template`` covering internal reference, name, barcode and
+variant attribute values, and exposes it in their search views as
+"Product (Ranked by Relevance)". Whole-value internal reference matches
+rank first.
+
+Dropdown (``name_search``) ranking is opted in per view by the
+``product_search_rank_sale`` / ``_purchase`` / ``_account`` modules.

--- a/product_search_rank/__init__.py
+++ b/product_search_rank/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/product_search_rank/__manifest__.py
+++ b/product_search_rank/__manifest__.py
@@ -1,0 +1,15 @@
+{
+    "name": "product_search_rank",
+    "summary": "Ranked substring + fuzzy searching for products",
+    "author": "Glo Networks",
+    "website": "https://github.com/GlodoUK/odoo-addons",
+    "category": "Hidden",
+    "development_status": "Alpha",
+    "version": "19.0.1.0.0",
+    "depends": ["product", "base_search_rank"],
+    "data": [
+        "views/product_product.xml",
+        "views/product_template.xml",
+    ],
+    "license": "Other proprietary",
+}

--- a/product_search_rank/models/__init__.py
+++ b/product_search_rank/models/__init__.py
@@ -1,0 +1,2 @@
+from . import product_product
+from . import product_template

--- a/product_search_rank/models/product_product.py
+++ b/product_search_rank/models/product_product.py
@@ -1,0 +1,19 @@
+from odoo import models
+
+from odoo.addons.base_search_rank.fields import SearchRank
+
+
+class ProductProduct(models.Model):
+    _name = "product.product"
+    _inherit = ["product.product", "base_search_rank.mixin"]
+
+    # display_name decomposed into its stored constituents: it is non-stored
+    # and context/language-dependent, so it cannot anchor a stored document
+    search_rank = SearchRank(
+        sources=(
+            "=default_code",
+            "product_tmpl_id.name",
+            "product_template_attribute_value_ids.name",
+            "barcode",
+        ),
+    )

--- a/product_search_rank/models/product_template.py
+++ b/product_search_rank/models/product_template.py
@@ -1,0 +1,19 @@
+from odoo import models
+
+from odoo.addons.base_search_rank.fields import SearchRank
+
+
+class ProductTemplate(models.Model):
+    _name = "product.template"
+    _inherit = ["product.template", "base_search_rank.mixin"]
+
+    # the template's own default_code/barcode are non-stored computes over
+    # the variants, so the document (and the exact boost, via a one2many
+    # hop) reads the variant columns directly
+    search_rank = SearchRank(
+        sources=(
+            "=product_variant_ids.default_code",
+            "name",
+            "product_variant_ids.barcode",
+        ),
+    )

--- a/product_search_rank/pyproject.toml
+++ b/product_search_rank/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["whool"]
+build-backend = "whool.buildapi"

--- a/product_search_rank/views/product_product.xml
+++ b/product_search_rank/views/product_product.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <record id="product_search_form_view_search_rank" model="ir.ui.view">
+        <field name="name">product.product.search.search.rank</field>
+        <field name="model">product.product</field>
+        <field name="inherit_id" ref="product.product_search_form_view" />
+        <field name="arch" type="xml">
+            <field name="name" position="before">
+                <field name="search_rank" string="Product (Ranked by Relevance)" />
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/product_search_rank/views/product_template.xml
+++ b/product_search_rank/views/product_template.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <record id="product_template_search_view_search_rank" model="ir.ui.view">
+        <field name="name">product.template.search.search.rank</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="product.product_template_search_view" />
+        <field name="arch" type="xml">
+            <field name="name" position="before">
+                <field name="search_rank" string="Product (Ranked by Relevance)" />
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/product_search_rank_account/README.rst
+++ b/product_search_rank_account/README.rst
@@ -1,0 +1,7 @@
+===========================
+product_search_rank_account
+===========================
+
+Opts the invoice line product dropdowns into the ranked + fuzzy
+``name_search`` from ``product_search_rank``, via ``search_rank_enable``
+in the field context.

--- a/product_search_rank_account/__manifest__.py
+++ b/product_search_rank_account/__manifest__.py
@@ -1,0 +1,14 @@
+{
+    "name": "product_search_rank_account",
+    "summary": "Ranked product searching in invoice line dropdowns",
+    "author": "Glo Networks",
+    "website": "https://github.com/GlodoUK/odoo-addons",
+    "category": "Hidden",
+    "development_status": "Alpha",
+    "version": "19.0.1.0.0",
+    "depends": ["product_search_rank", "account", "base_view_inheritance_extension"],
+    "data": [
+        "views/account_move_views.xml",
+    ],
+    "license": "Other proprietary",
+}

--- a/product_search_rank_account/pyproject.toml
+++ b/product_search_rank_account/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["whool"]
+build-backend = "whool.buildapi"

--- a/product_search_rank_account/views/account_move_views.xml
+++ b/product_search_rank_account/views/account_move_views.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <!-- Opt the invoice line product dropdowns into ranked name_search.
+         operation="update" (base_view_inheritance_extension) merges into
+         the existing context (or creates one where the field has none). -->
+    <record id="view_move_form_search_rank" model="ir.ui.view">
+        <field name="name">account.move.form.search.rank</field>
+        <field name="model">account.move</field>
+        <field name="inherit_id" ref="account.view_move_form" />
+        <field name="arch" type="xml">
+            <xpath
+                expr="//field[@name='invoice_line_ids']/list//field[@name='product_id']"
+                position="attributes"
+            >
+                <attribute name="context" operation="update">
+                    {"search_rank_enable": True}
+                </attribute>
+            </xpath>
+            <xpath
+                expr="//field[@name='invoice_line_ids']/form//field[@name='product_id']"
+                position="attributes"
+            >
+                <attribute name="context" operation="update">
+                    {"search_rank_enable": True}
+                </attribute>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/product_search_rank_purchase/README.rst
+++ b/product_search_rank_purchase/README.rst
@@ -1,0 +1,7 @@
+============================
+product_search_rank_purchase
+============================
+
+Opts the purchase order line product dropdowns into the ranked + fuzzy
+``name_search`` from ``product_search_rank``, via ``search_rank_enable``
+in the field context.

--- a/product_search_rank_purchase/__manifest__.py
+++ b/product_search_rank_purchase/__manifest__.py
@@ -1,0 +1,14 @@
+{
+    "name": "product_search_rank_purchase",
+    "summary": "Ranked product searching in purchase order line dropdowns",
+    "author": "Glo Networks",
+    "website": "https://github.com/GlodoUK/odoo-addons",
+    "category": "Hidden",
+    "development_status": "Alpha",
+    "version": "19.0.1.0.0",
+    "depends": ["product_search_rank", "purchase", "base_view_inheritance_extension"],
+    "data": [
+        "views/purchase_views.xml",
+    ],
+    "license": "Other proprietary",
+}

--- a/product_search_rank_purchase/pyproject.toml
+++ b/product_search_rank_purchase/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["whool"]
+build-backend = "whool.buildapi"

--- a/product_search_rank_purchase/views/purchase_views.xml
+++ b/product_search_rank_purchase/views/purchase_views.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <!-- Opt the PO line product dropdowns into ranked name_search.
+         operation="update" (base_view_inheritance_extension) merges into
+         the existing context instead of replacing it. -->
+    <record id="purchase_order_form_search_rank" model="ir.ui.view">
+        <field name="name">purchase.order.form.search.rank</field>
+        <field name="model">purchase.order</field>
+        <field name="inherit_id" ref="purchase.purchase_order_form" />
+        <field name="arch" type="xml">
+            <xpath
+                expr="//field[@name='order_line']/list//field[@name='product_id']"
+                position="attributes"
+            >
+                <attribute name="context" operation="update">
+                    {"search_rank_enable": True}
+                </attribute>
+            </xpath>
+            <xpath
+                expr="//field[@name='order_line']/form//field[@name='product_id']"
+                position="attributes"
+            >
+                <attribute name="context" operation="update">
+                    {"search_rank_enable": True}
+                </attribute>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/product_search_rank_sale/README.rst
+++ b/product_search_rank_sale/README.rst
@@ -1,0 +1,7 @@
+========================
+product_search_rank_sale
+========================
+
+Opts the sale order line product dropdowns (``product_id`` and
+``product_template_id``) into the ranked + fuzzy ``name_search`` from
+``product_search_rank``, via ``search_rank_enable`` in the field context.

--- a/product_search_rank_sale/__manifest__.py
+++ b/product_search_rank_sale/__manifest__.py
@@ -1,0 +1,14 @@
+{
+    "name": "product_search_rank_sale",
+    "summary": "Ranked product searching in sale order line dropdowns",
+    "author": "Glo Networks",
+    "website": "https://github.com/GlodoUK/odoo-addons",
+    "category": "Hidden",
+    "development_status": "Alpha",
+    "version": "19.0.1.0.0",
+    "depends": ["product_search_rank", "sale", "base_view_inheritance_extension"],
+    "data": [
+        "views/sale_order_views.xml",
+    ],
+    "license": "Other proprietary",
+}

--- a/product_search_rank_sale/pyproject.toml
+++ b/product_search_rank_sale/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["whool"]
+build-backend = "whool.buildapi"

--- a/product_search_rank_sale/views/sale_order_views.xml
+++ b/product_search_rank_sale/views/sale_order_views.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <!-- Opt the SO line product dropdowns into ranked name_search.
+         operation="update" (base_view_inheritance_extension) merges into
+         the core context instead of replacing it. -->
+    <record id="view_order_form_search_rank" model="ir.ui.view">
+        <field name="name">sale.order.form.search.rank</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form" />
+        <field name="arch" type="xml">
+            <xpath
+                expr="//field[@name='order_line']/form//field[@name='product_id']"
+                position="attributes"
+            >
+                <attribute name="context" operation="update">
+                    {"search_rank_enable": True}
+                </attribute>
+            </xpath>
+            <xpath
+                expr="//field[@name='order_line']/list//field[@name='product_id']"
+                position="attributes"
+            >
+                <attribute name="context" operation="update">
+                    {"search_rank_enable": True}
+                </attribute>
+            </xpath>
+            <xpath
+                expr="//field[@name='order_line']/list//field[@name='product_template_id']"
+                position="attributes"
+            >
+                <attribute name="context" operation="update">
+                    {"search_rank_enable": True}
+                </attribute>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Fixes T17128

**Dependencies:**
- N/A

**ARL (Associated Risk Level):**
- [ ] Low
- [ ] Medium
- [ ] High

**Type of change:**
- [ ] Forwardport / Backport
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/GlodoUK/codesmith/odoo-addons/pr/315"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788453178&installation_model_id=426334&pr_number=315&repository=GlodoUK%2Fodoo-addons&return_to=https%3A%2F%2Fgithub.com%2FGlodoUK%2Fodoo-addons%2Fpull%2F315&signature=5e80e9c0bad25b44aba6f0ef6d21c5ff70ebed653d7c26478d964292b2f0327f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->