### PR TITLE
[ADD] sale_delivery_auto: Automatically update a sale.order carrier and price

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ env:
   # "Rebel" modules: addons that must be tested in isolation. Comma separated.
   # Each gets its own database/run and is excluded from the main run.
   # To add one, append its technical name to the list, e.g. "foo,bar".
-  REBEL_MODULES: "sale_delivery_required,sale_invoice_consolidation"
+  REBEL_MODULES: "sale_delivery_required,sale_delivery_auto,sale_invoice_consolidation"
 
 jobs:
   pre-commit:

--- a/sale_check_product_pricelist/tests/test_check_product_pricelist.py
+++ b/sale_check_product_pricelist/tests/test_check_product_pricelist.py
@@ -33,18 +33,26 @@ class TestCheckProductPricelist(SaleCommon):
             }
         )
 
+    def _line(self, order, product):
+        """The order's line for `product`.
+
+        Other modules add lines of their own - sale_delivery_auto puts a
+        shipping cost line on anything physical - so never read `order_line` as
+        a single record.
+        """
+        return order.order_line.filtered(lambda line: line.product_id == product)
+
     def test_default_behaviour_ignores_pricelist(self):
         """The Odoo default sells anything, priced on the pricelist or not."""
         self.assertEqual(self.pricelist.check_sale_behaviour, "default")
         order = self._create_order(self.unpriced_product)
+        line = self._line(order, self.unpriced_product)
 
         # 'default' is permissive precisely because nothing implements it: the
         # dispatch reads a missing hook as "no check".
-        self.assertFalse(
-            hasattr(order.order_line, "_pricelist_check_sale_behaviour_default")
-        )
-        self.assertFalse(order.order_line.pricelist_item_id)
-        self.assertTrue(order.order_line._pricelist_check_sale_behaviour())
+        self.assertFalse(hasattr(line, "_pricelist_check_sale_behaviour_default"))
+        self.assertFalse(line.pricelist_item_id)
+        self.assertTrue(line._pricelist_check_sale_behaviour())
         self.assertFalse(order._confirmation_error_message())
 
         order.action_confirm()
@@ -54,8 +62,9 @@ class TestCheckProductPricelist(SaleCommon):
         """Under 'explicit', a product with no matching rule blocks confirmation."""
         self.pricelist.check_sale_behaviour = "explicit"
         order = self._create_order(self.unpriced_product)
+        line = self._line(order, self.unpriced_product)
 
-        self.assertFalse(order.order_line._pricelist_check_sale_behaviour())
+        self.assertFalse(line._pricelist_check_sale_behaviour())
         self.assertIn(
             self.unpriced_product.display_name,
             order._confirmation_error_message(),
@@ -68,9 +77,10 @@ class TestCheckProductPricelist(SaleCommon):
         """Under 'explicit', a product matched by a rule confirms as normal."""
         self.pricelist.check_sale_behaviour = "explicit"
         order = self._create_order(self.priced_product)
+        line = self._line(order, self.priced_product)
 
-        self.assertTrue(order.order_line.pricelist_item_id)
-        self.assertTrue(order.order_line._pricelist_check_sale_behaviour())
+        self.assertTrue(line.pricelist_item_id)
+        self.assertTrue(line._pricelist_check_sale_behaviour())
         self.assertFalse(order._confirmation_error_message())
 
         order.action_confirm()

--- a/sale_delivery_auto/README.rst
+++ b/sale_delivery_auto/README.rst
@@ -1,0 +1,106 @@
+==================
+sale_delivery_auto
+==================
+
+Picks the delivery method for a sales order, and keeps the shipping cost line
+in step with it.
+
+Carrier selection
+=================
+
+Every ``delivery.carrier`` in the order's company is considered in sequence
+order - the order they are listed in - and the **first one that is available**
+for the order is assigned. Availability is core's own test
+(``available_carriers``): destination country, state, zip prefix, maximum
+weight, maximum volume and product tags.
+
+The selection runs when an order is created, when a field that could change the
+answer is written, when order lines are added, changed or removed - whether the
+lines are written directly or arrive as one2many commands in a write on the
+order, which is how the form saves them - and again on confirmation.
+
+It runs on stored orders only: there is no onchange, so nothing happens while a
+form is open and the delivery method appears when the order is saved. The
+shipping cost line needs a real ``order_id`` to exist at all, so an onchange
+could only ever do half the job, and the "Add shipping" wizard works from a
+saved order regardless.
+
+Because the selection is re-run rather than done once, an order always carries
+the first carrier that is genuinely available for it - if a change puts the
+order over a carrier's weight limit, the next one down the list takes over.
+
+Honouring a manual choice
+=========================
+
+A carrier chosen by hand is never replaced.
+
+``delivery_carrier_manual`` is set by one thing: choosing the delivery method
+outright, through the "Add shipping" wizard. From that point the order keeps its
+carrier, even if that carrier stops being available for it.
+
+Nothing else counts. A bare write to ``carrier_id`` - a script, a connector, an
+``import`` - is not a choice, and the selection will answer over it on the next
+change. Code that means to pin a carrier says so::
+
+    order.write({"carrier_id": carrier.id, "delivery_carrier_manual": True})
+
+Deleting the shipping cost line does count, though it is not the wizard.
+``delivery`` clears ``carrier_id`` when that line goes, so deleting it reads as
+"no delivery method, thank you" and is left standing rather than being put
+straight back. Our own tidy-up of that line - an order with nothing left to ship
+- is not read that way.
+
+Untick **Delivery Method Chosen Manually** on the order to hand the choice back
+to the automatic selection.
+
+Shipping cost
+=============
+
+The shipping cost line is created and refreshed from
+``carrier.rate_shipment()``. This happens for a manually chosen carrier too -
+the manual flag protects the choice of carrier, not the price.
+
+Refreshes are driven by an explicit list of trigger fields rather than by every
+write.
+
+If the carrier cannot rate the order the failure is logged, ``delivery_message``
+is set and ``recompute_delivery_price`` is flagged so the "Update shipping cost"
+button appears. The save is never blocked.
+
+Nothing is touched once the order leaves ``draft``/``sent``: after confirmation
+the shipping cost is a commercial agreement, not something to quietly re-rate.
+
+Opting out
+==========
+
+``skip_delivery_auto=True`` on the context stops both the carrier selection and
+the price refresh, for imports, connectors and data migrations::
+
+    order.with_context(skip_delivery_auto=True).write(vals)
+
+There is no per-order opt-out field. For a single order, choosing the delivery
+method by hand is the opt-out: that sets *Delivery Method Chosen Manually* and
+the selection leaves it alone from then on.
+
+Relationship to the OCA modules
+===============================
+
+Replaces ``sale_order_carrier_auto_assign`` and ``delivery_auto_refresh``. Both
+are in ``excludes``, along with ``sale_delivery_required``, so Odoo refuses to
+install them alongside this module rather than leaving two answers to fight over
+an order. The differences that matter:
+
+* ``sale_order_carrier_auto_assign`` only ever considers the partner's
+  ``property_delivery_carrier_id``. This module considers every carrier and
+  takes the first available one.
+* ``delivery_auto_refresh`` re-runs on *every* write to an order or an order
+  line. This module runs on a declared set of trigger fields.
+* Neither has a notion of a carrier that was chosen deliberately, so a manual
+  choice does not survive the next write.
+* Both are driven by company-level settings. This module's configuration is in
+  code, and opting out is a context key.
+
+``sale_delivery_required`` is excluded for a different reason: it refuses to
+confirm an order with no delivery method, and an order with no delivery method
+is an answer this module is willing to give - a service-only order, or one whose
+shipping cost line was deleted.

--- a/sale_delivery_auto/__init__.py
+++ b/sale_delivery_auto/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/sale_delivery_auto/__manifest__.py
+++ b/sale_delivery_auto/__manifest__.py
@@ -1,0 +1,23 @@
+{
+    "name": "sale_delivery_auto",
+    "summary": "Assign the first available delivery carrier and keep the "
+    "shipping cost up to date, without trampling manual edits",
+    "author": "Glo Networks",
+    "website": "https://github.com/GlodoUK/odoo-addons",
+    "category": "Inventory/Delivery",
+    "version": "19.0.1.0.0",
+    "depends": ["sale", "delivery"],
+    # Each of these answers the same question its own way, and two answers is
+    # worse than either: the OCA pair assigns and re-rates on their own terms,
+    # and sale_delivery_required blocks a confirmation this module deliberately
+    # allows - an order whose shipping cost line was deleted.
+    "excludes": [
+        "delivery_auto_refresh",
+        "sale_delivery_required",
+        "sale_order_carrier_auto_assign",
+    ],
+    "data": [
+        "views/sale_order.xml",
+    ],
+    "license": "LGPL-3",
+}

--- a/sale_delivery_auto/models/__init__.py
+++ b/sale_delivery_auto/models/__init__.py
@@ -1,0 +1,2 @@
+from . import sale_order
+from . import sale_order_line

--- a/sale_delivery_auto/models/sale_order.py
+++ b/sale_delivery_auto/models/sale_order.py
@@ -1,0 +1,211 @@
+import logging
+
+from odoo import api, fields, models
+
+_logger = logging.getLogger(__name__)
+
+# Callers set this to keep us out of a whole flow (imports, connectors, data
+# migrations). We also set it on ourselves while working, so the writes we make
+# do not come back in through create/write/unlink.
+SKIP = "skip_delivery_auto"
+
+# Set while a write on the order is in flight, so the hooks on sale.order.line
+# stay quiet for the one2many commands it carries: the order answers for its own
+# lines once, from the top, rather than once per command. Deliberately not SKIP -
+# a shipping cost line deleted this way is still somebody deleting it, and the
+# line hook has to be able to tell that from our own tidying up.
+IN_ORDER_WRITE = "delivery_auto_in_order_write"
+
+# Order fields whose change makes the carrier choice, or the shipping cost,
+# stale. In code on purpose: this is not something to hand to a user.
+ORDER_TRIGGERS = frozenset(
+    {
+        "carrier_id",
+        "company_id",
+        "currency_id",
+        "date_order",
+        "delivery_carrier_manual",
+        "fiscal_position_id",
+        # Lines arriving as one2many commands inside a write on the order - how
+        # the form, and most code, saves them - go in with our own context on,
+        # so the hooks on sale.order.line stay quiet for them. The order has to
+        # answer for its own lines.
+        "order_line",
+        "partner_id",
+        "partner_shipping_id",
+        "pricelist_id",
+        "warehouse_id",
+    }
+)
+
+
+class SaleOrder(models.Model):
+    _inherit = "sale.order"
+
+    delivery_carrier_manual = fields.Boolean(
+        string="Delivery Method Chosen Manually",
+        help="The delivery method on this order was chosen by hand, so it is "
+        "never replaced automatically. Untick to hand the choice back to the "
+        "automatic selection.",
+    )
+
+    def _delivery_auto_stopped(self):
+        context = self.env.context
+        return bool(context.get(SKIP) or context.get(IN_ORDER_WRITE))
+
+    def _delivery_auto_editable(self):
+        self.ensure_one()
+        return self.state in ("draft", "sent")
+
+    def _delivery_auto_has_goods(self):
+        self.ensure_one()
+        return bool(
+            self.order_line.filtered(
+                lambda line: (
+                    line.product_id.type == "consu"
+                    and line.product_uom_qty > 0
+                    and not line.display_type
+                    and not line.is_delivery
+                )
+            )
+        )
+
+    def _delivery_auto_pick_carrier(self):
+        self.ensure_one()
+        order = self.with_company(self.company_id)
+        model = self.env["delivery.carrier"]
+        # delivery.carrier is ordered by sequence, so "the first available one"
+        # follows the list as it reads in the UI.
+        carriers = model.search(model._check_company_domain(self.company_id))
+        return carriers.available_carriers(order.partner_shipping_id, order)[:1]
+
+    def _delivery_auto_set_carrier(self):
+        for order in self:
+            if (
+                order.delivery_carrier_manual
+                or not order._delivery_auto_editable()
+                or not order._delivery_auto_has_goods()
+            ):
+                continue
+            carrier = order._delivery_auto_pick_carrier()
+            if carrier != order.carrier_id:
+                # Say so explicitly: writing carrier_id without this is what
+                # marks a delivery method as chosen by hand.
+                order.write(
+                    {
+                        "carrier_id": carrier.id,
+                        "delivery_carrier_manual": False,
+                    }
+                )
+
+    def _delivery_auto_line_vals(self, line, price_unit):
+        """Values to sync onto an existing shipping cost line."""
+        self.ensure_one()
+        vals = self._prepare_delivery_line_vals(self.carrier_id, price_unit)
+        # These say where the line lives, not what it costs.
+        vals.pop("order_id", None)
+        vals.pop("sequence", None)
+        # Leave a hand-written description alone unless the carrier changed.
+        if line.product_id == self.carrier_id.product_id:
+            vals.pop("name", None)
+        # `sale` reads price_unit drifting from technical_price_unit as "a human
+        # typed this in" and stops recomputing the line. Move them together.
+        vals["technical_price_unit"] = vals["price_unit"]
+        return vals
+
+    def _delivery_auto_refresh_price(self):
+        self.ensure_one()
+        if not self._delivery_auto_editable():
+            return
+        line = self.order_line.filtered("is_delivery")[:1]
+        if not self._delivery_auto_has_goods():
+            # Nothing ships, so there is nothing to charge for. `delivery`
+            # clears carrier_id as the line goes and that write would read as a
+            # manual choice, so state the outcome ourselves: this tidy-up is
+            # ours, not somebody's decision.
+            if line or self.carrier_id:
+                self.write({"carrier_id": False, "delivery_carrier_manual": False})
+            if line:
+                self._remove_delivery_line()
+            return
+        if not self.carrier_id:
+            # Somebody cleared the delivery method. Drop the cost line with it
+            # and leave that choice standing.
+            if line:
+                self._remove_delivery_line()
+            return
+        rate = self.carrier_id.rate_shipment(self)
+        if not rate.get("success"):
+            _logger.info(
+                "%s: %s could not rate this order: %s",
+                self.display_name,
+                self.carrier_id.display_name,
+                rate.get("error_message"),
+            )
+            # Never block the save over this; flag it for the "Update shipping
+            # cost" button instead.
+            self.write(
+                {
+                    "delivery_message": rate.get("error_message") or False,
+                    "recompute_delivery_price": True,
+                }
+            )
+            return
+        if line:
+            line.write(self._delivery_auto_line_vals(line, rate["price"]))
+        else:
+            self._create_delivery_line(self.carrier_id, rate["price"])
+        self.write(
+            {
+                "delivery_message": rate.get("warning_message") or False,
+                "recompute_delivery_price": False,
+            }
+        )
+
+    def _delivery_auto_run(self):
+        for order in self.with_context(**{SKIP: True}):
+            order._delivery_auto_set_carrier()
+            order._delivery_auto_refresh_price()
+
+    def _prepare_delivery_line_vals(self, carrier, price_unit):
+        vals = super()._prepare_delivery_line_vals(carrier, price_unit)
+        # XXX: Pin the uom, it would otherwise be recomputed from the product and
+        # we get stuck in a loop
+        vals["product_uom_id"] = carrier.product_id.uom_id.id
+        return vals
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        orders = super(SaleOrder, self.with_context(**{IN_ORDER_WRITE: True})).create(
+            vals_list
+        )
+        # Hand the caller back records in the caller's own environment: our
+        # context is for the create in flight, and going out on the returned
+        # recordset would quietly mute every later write on it - and on its
+        # lines, which inherit it.
+        orders = orders.with_env(self.env)
+        if not self._delivery_auto_stopped():
+            orders._delivery_auto_run()
+        return orders
+
+    def write(self, vals):
+        res = super(SaleOrder, self.with_context(**{IN_ORDER_WRITE: True})).write(vals)
+        if not self._delivery_auto_stopped() and set(vals) & ORDER_TRIGGERS:
+            self._delivery_auto_run()
+        return res
+
+    def set_delivery_line(self, carrier, amount):
+        # Somebody choosing the delivery method outright - the "Add shipping"
+        # wizard, a customer picking one at checkout - is the one thing that
+        # marks a carrier as chosen by hand. Muted while it happens: the carrier
+        # and the price are the caller's, and we are not to answer over them.
+        orders = self.with_context(**{SKIP: True})
+        res = super(SaleOrder, orders).set_delivery_line(carrier, amount)
+        orders.delivery_carrier_manual = True
+        return res
+
+    def action_confirm(self):
+        # XXX: Last chance to get a carrier and a shipping cost onto the order.
+        if not self._delivery_auto_stopped():
+            self._delivery_auto_run()
+        return super().action_confirm()

--- a/sale_delivery_auto/models/sale_order_line.py
+++ b/sale_delivery_auto/models/sale_order_line.py
@@ -1,0 +1,80 @@
+from odoo import api, models
+
+from .sale_order import IN_ORDER_WRITE, SKIP
+
+# Line fields whose change moves the shipping cost: carriers rate on weight,
+# volume and order value, and free_over on the order total.
+LINE_TRIGGERS = frozenset(
+    {
+        "discount",
+        "price_unit",
+        "product_id",
+        "product_uom_id",
+        "product_uom_qty",
+        "tax_ids",
+    }
+)
+
+
+class SaleOrderLine(models.Model):
+    _inherit = "sale.order.line"
+
+    def _delivery_auto_muted(self):
+        # sale_write_from_compute is `sale` recomputing a price off the back of a
+        # change we have already been told about. IN_ORDER_WRITE is a write on
+        # the order carrying these lines as one2many commands: it answers for
+        # them itself, once, rather than once per command.
+        context = self.env.context
+        return bool(
+            context.get(SKIP)
+            or context.get(IN_ORDER_WRITE)
+            or context.get("sale_write_from_compute")
+        )
+
+    def _delivery_auto_orders(self):
+        # The shipping cost line is our own output; a change to it says nothing
+        # about what the carrier should charge.
+        return self.filtered(lambda line: not line.is_delivery).order_id
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        muted = self._delivery_auto_muted()
+        lines = super(SaleOrderLine, self.with_context(**{SKIP: True})).create(
+            vals_list
+        )
+        # Back to the caller's environment: SKIP riding out on the returned
+        # lines would mute every later write on them.
+        lines = lines.with_env(self.env)
+        if not muted:
+            lines._delivery_auto_orders()._delivery_auto_run()
+        return lines
+
+    def write(self, vals):
+        muted = self._delivery_auto_muted()
+        orders = self._delivery_auto_orders()
+        res = super(SaleOrderLine, self.with_context(**{SKIP: True})).write(vals)
+        if not muted and set(vals) & LINE_TRIGGERS:
+            orders._delivery_auto_run()
+        return res
+
+    def unlink(self):
+        muted = self._delivery_auto_muted()
+        orders = self._delivery_auto_orders()
+        dropped = self.filtered("is_delivery").order_id
+        # Muted throughout: `delivery` clears carrier_id from inside unlink(),
+        # before the rows go, and letting that write re-run us mid-unlink would
+        # remove the shipping cost line a second time.
+        res = super(SaleOrderLine, self.with_context(**{SKIP: True})).unlink()
+        dropped = dropped.exists()
+        # Losing the shipping cost line takes the carrier with it, so read that
+        # as "no delivery method, thank you" rather than putting the line
+        # straight back. Recorded even under IN_ORDER_WRITE, where the order is
+        # about to ask us for an answer - but not under SKIP, which is us
+        # tidying up after an order with nothing left to ship, and callers who
+        # asked to be left alone.
+        if not self.env.context.get(SKIP):
+            dropped.with_context(**{SKIP: True}).delivery_carrier_manual = True
+        if muted:
+            return res
+        (orders.exists() - dropped)._delivery_auto_run()
+        return res

--- a/sale_delivery_auto/pyproject.toml
+++ b/sale_delivery_auto/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["whool"]
+build-backend = "whool.buildapi"

--- a/sale_delivery_auto/tests/__init__.py
+++ b/sale_delivery_auto/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_sale_delivery_auto

--- a/sale_delivery_auto/tests/test_sale_delivery_auto.py
+++ b/sale_delivery_auto/tests/test_sale_delivery_auto.py
@@ -1,0 +1,409 @@
+from odoo import Command
+from odoo.tests import Form
+from odoo.tests.common import TransactionCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestSaleDeliveryAuto(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        # The development database is a copy of production, so the carriers it
+        # already holds would decide "first available" for us.
+        cls.env["delivery.carrier"].search([]).write({"active": False})
+
+        cls.company = cls.env.company
+        cls.uk = cls.env.ref("base.uk")
+        cls.fr = cls.env.ref("base.fr")
+
+        # Pin the currency so the price rules below are the whole story.
+        cls.pricelist = cls.env["product.pricelist"].create(
+            {
+                "name": "sale_delivery_auto tests",
+                "currency_id": cls.company.currency_id.id,
+            }
+        )
+        cls.partner = cls.env["res.partner"].create(
+            {
+                "name": "sale_delivery_auto customer",
+                "country_id": cls.uk.id,
+                "zip": "LS1 1AA",
+                "property_product_pricelist": cls.pricelist.id,
+            }
+        )
+
+        cls.product = cls.env["product.product"].create(
+            {
+                "name": "sale_delivery_auto widget",
+                "default_code": "SDA-WIDGET",
+                "type": "consu",
+                "weight": 1.0,
+                "list_price": 100.0,
+            }
+        )
+        cls.service = cls.env["product.product"].create(
+            {
+                "name": "sale_delivery_auto service",
+                "default_code": "SDA-SERVICE",
+                "type": "service",
+                "list_price": 50.0,
+            }
+        )
+
+        # Two carriers charging per unit, so a rate is exact and moves with the
+        # order. "first" sorts ahead of "second" on sequence.
+        cls.carrier_first = cls._make_carrier("SDA First", sequence=1, unit_price=2.0)
+        cls.carrier_second = cls._make_carrier("SDA Second", sequence=2, unit_price=5.0)
+
+    @classmethod
+    def _make_carrier(cls, name, sequence, unit_price, **vals):
+        product = cls.env["product.product"].create(
+            {
+                "name": f"{name} delivery",
+                "default_code": f"SDA-{name.replace(' ', '-').upper()}",
+                "type": "service",
+                "list_price": 0.0,
+            }
+        )
+        return cls.env["delivery.carrier"].create(
+            {
+                "name": name,
+                "sequence": sequence,
+                "product_id": product.id,
+                "delivery_type": "base_on_rule",
+                "price_rule_ids": [
+                    Command.create(
+                        {
+                            "variable": "quantity",
+                            "operator": "<=",
+                            "max_value": 10000.0,
+                            "list_price": unit_price,
+                            "variable_factor": "quantity",
+                        }
+                    )
+                ],
+                **vals,
+            }
+        )
+
+    def _make_order(self, qty=3, product=None, **vals):
+        return self.env["sale.order"].create(
+            {
+                "partner_id": self.partner.id,
+                "pricelist_id": self.pricelist.id,
+                "order_line": [
+                    Command.create(
+                        {
+                            "product_id": (product or self.product).id,
+                            "product_uom_qty": qty,
+                        }
+                    )
+                ],
+                **vals,
+            }
+        )
+
+    def _delivery_line(self, order):
+        return order.order_line.filtered("is_delivery")
+
+    def _choose_carrier(self, order, carrier):
+        """Choose a delivery method the way a user does: through the wizard."""
+        wizard = (
+            self.env["choose.delivery.carrier"]
+            .with_context(default_order_id=order.id)
+            .create({"order_id": order.id, "carrier_id": carrier.id})
+        )
+        wizard.update_price()
+        wizard.button_confirm()
+        return wizard
+
+    def test_first_available_carrier_is_assigned(self):
+        order = self._make_order()
+        self.assertEqual(order.carrier_id, self.carrier_first)
+        self.assertFalse(order.delivery_carrier_manual)
+
+    def test_sequence_decides_which_carrier_wins(self):
+        self.carrier_second.sequence = 0
+        order = self._make_order()
+        self.assertEqual(order.carrier_id, self.carrier_second)
+
+    def test_unavailable_carrier_is_passed_over(self):
+        self.carrier_first.country_ids = [Command.set(self.fr.ids)]
+        order = self._make_order()
+        self.assertEqual(order.carrier_id, self.carrier_second)
+
+    def test_carrier_over_weight_limit_is_passed_over(self):
+        self.carrier_first.max_weight = 2.0
+        order = self._make_order(qty=3)
+        self.assertEqual(order.carrier_id, self.carrier_second)
+
+    def test_carrier_assigned_when_first_line_is_added(self):
+        order = self.env["sale.order"].create(
+            {"partner_id": self.partner.id, "pricelist_id": self.pricelist.id}
+        )
+        self.assertFalse(order.carrier_id)
+        self.env["sale.order.line"].create(
+            {
+                "order_id": order.id,
+                "product_id": self.product.id,
+                "product_uom_qty": 2,
+            }
+        )
+        self.assertEqual(order.carrier_id, self.carrier_first)
+
+    def test_service_only_order_gets_nothing(self):
+        order = self._make_order(product=self.service)
+        self.assertFalse(order.carrier_id)
+        self.assertFalse(self._delivery_line(order))
+
+    def test_order_going_all_service_and_back(self):
+        order = self._make_order(qty=3)
+        self.assertEqual(order.carrier_id, self.carrier_first)
+        service_line = self.env["sale.order.line"].create(
+            {
+                "order_id": order.id,
+                "product_id": self.service.id,
+                "product_uom_qty": 1,
+            }
+        )
+        # Nothing physical left to ship: carrier and shipping cost both go, but
+        # that is us tidying up, not somebody choosing "no delivery method".
+        order.order_line.filtered(lambda line: line.product_id == self.product).unlink()
+        self.assertFalse(order.carrier_id)
+        self.assertFalse(self._delivery_line(order))
+        self.assertFalse(order.delivery_carrier_manual)
+        # So putting goods back on the order picks a carrier again.
+        service_line.unlink()
+        self.env["sale.order.line"].create(
+            {
+                "order_id": order.id,
+                "product_id": self.product.id,
+                "product_uom_qty": 2,
+            }
+        )
+        self.assertEqual(order.carrier_id, self.carrier_first)
+        self.assertEqual(self._delivery_line(order).price_unit, 4.0)
+
+    def test_combo_only_order_gets_nothing(self):
+        # A combo is not a service, so a "not a service" test would treat this
+        # as shippable. Only `consu` actually ships.
+        choice = self.env["product.combo"].create(
+            {
+                "name": "sale_delivery_auto combo choice",
+                "combo_item_ids": [Command.create({"product_id": self.service.id})],
+            }
+        )
+        combo = self.env["product.product"].create(
+            {
+                "name": "sale_delivery_auto combo",
+                "default_code": "SDA-COMBO",
+                "type": "combo",
+                "combo_ids": [Command.set(choice.ids)],
+            }
+        )
+        order = self._make_order(product=combo, qty=1)
+        self.assertFalse(order.carrier_id)
+        self.assertFalse(self._delivery_line(order))
+
+    def test_zero_quantity_leaves_nothing_to_ship(self):
+        order = self._make_order(qty=3)
+        self.assertEqual(order.carrier_id, self.carrier_first)
+        # Same test `delivery` applies when it weighs an order: no quantity, no
+        # shipment, so no carrier and no cost line.
+        order.order_line[0].product_uom_qty = 0
+        self.assertFalse(order.carrier_id)
+        self.assertFalse(self._delivery_line(order))
+        # Tidying up is ours, so putting a quantity back picks a carrier again.
+        self.assertFalse(order.delivery_carrier_manual)
+        order.order_line[0].product_uom_qty = 5
+        self.assertEqual(order.carrier_id, self.carrier_first)
+        self.assertEqual(self._delivery_line(order).price_unit, 10.0)
+
+    def test_writing_the_carrier_directly_is_not_a_choice(self):
+        # Choosing the delivery method means the wizard. A bare write to
+        # carrier_id - a script, a connector - is not that, so the selection is
+        # free to answer over it.
+        order = self._make_order(qty=3)
+        order.carrier_id = self.carrier_second
+        self.assertFalse(order.delivery_carrier_manual)
+        self.assertEqual(order.carrier_id, self.carrier_first)
+        order.carrier_id = False
+        self.assertEqual(order.carrier_id, self.carrier_first)
+        self.assertTrue(self._delivery_line(order))
+
+    def test_carrier_reassessed_when_it_stops_being_available(self):
+        order = self._make_order()
+        self.assertEqual(order.carrier_id, self.carrier_first)
+        self.carrier_first.country_ids = [Command.set(self.fr.ids)]
+        # A trigger field changing re-runs the selection.
+        order.partner_shipping_id = self.partner
+        order.order_line[0].product_uom_qty = 4
+        self.assertEqual(order.carrier_id, self.carrier_second)
+
+    def test_manual_carrier_is_never_replaced(self):
+        order = self._make_order()
+        self._choose_carrier(order, self.carrier_second)
+        self.assertTrue(order.delivery_carrier_manual)
+        order.order_line[0].product_uom_qty = 7
+        self.assertEqual(order.carrier_id, self.carrier_second)
+
+    def test_manual_carrier_survives_becoming_unavailable(self):
+        order = self._make_order()
+        self._choose_carrier(order, self.carrier_second)
+        self.carrier_second.country_ids = [Command.set(self.fr.ids)]
+        order.order_line[0].product_uom_qty = 7
+        self.assertEqual(order.carrier_id, self.carrier_second)
+
+    def test_carrier_on_create_is_not_a_choice_on_its_own(self):
+        # Same rule as a write: a carrier handed to create is not the wizard.
+        order = self._make_order(carrier_id=self.carrier_second.id)
+        self.assertEqual(order.carrier_id, self.carrier_first)
+        self.assertFalse(order.delivery_carrier_manual)
+
+    def test_create_can_state_the_choice_itself(self):
+        # Which leaves the flag as the way for a connector to force a carrier.
+        order = self._make_order(
+            carrier_id=self.carrier_second.id, delivery_carrier_manual=True
+        )
+        self.assertEqual(order.carrier_id, self.carrier_second)
+        order.order_line[0].product_uom_qty = 7
+        self.assertEqual(order.carrier_id, self.carrier_second)
+
+    def test_clearing_the_manual_flag_hands_control_back(self):
+        order = self._make_order()
+        self._choose_carrier(order, self.carrier_second)
+        order.delivery_carrier_manual = False
+        self.assertEqual(order.carrier_id, self.carrier_first)
+
+    def test_wizard_marks_the_carrier_manual(self):
+        order = self._make_order()
+        self._choose_carrier(order, self.carrier_second)
+        self.assertEqual(order.carrier_id, self.carrier_second)
+        self.assertTrue(order.delivery_carrier_manual)
+        self.assertEqual(len(self._delivery_line(order)), 1)
+
+    def test_skip_context(self):
+        order = (
+            self.env["sale.order"]
+            .with_context(skip_delivery_auto=True)
+            .create(
+                {
+                    "partner_id": self.partner.id,
+                    "pricelist_id": self.pricelist.id,
+                    "order_line": [
+                        Command.create(
+                            {"product_id": self.product.id, "product_uom_qty": 3}
+                        )
+                    ],
+                }
+            )
+        )
+        self.assertFalse(order.carrier_id)
+        self.assertFalse(self._delivery_line(order))
+
+    def test_delivery_line_created_at_the_carrier_rate(self):
+        order = self._make_order(qty=3)
+        line = self._delivery_line(order)
+        self.assertEqual(len(line), 1)
+        self.assertEqual(line.product_id, self.carrier_first.product_id)
+        self.assertEqual(line.price_unit, 6.0)
+
+    def test_price_follows_the_quantity(self):
+        order = self._make_order(qty=3)
+        self.assertEqual(self._delivery_line(order).price_unit, 6.0)
+        order.order_line.filtered(
+            lambda line: not line.is_delivery
+        ).product_uom_qty = 10
+        self.assertEqual(self._delivery_line(order).price_unit, 20.0)
+
+    def test_price_follows_a_manual_carrier(self):
+        order = self._make_order(qty=3)
+        self._choose_carrier(order, self.carrier_second)
+        self.assertEqual(self._delivery_line(order).price_unit, 15.0)
+        order.order_line.filtered(lambda line: not line.is_delivery).product_uom_qty = 4
+        self.assertEqual(self._delivery_line(order).price_unit, 20.0)
+
+    def test_only_ever_one_delivery_line(self):
+        order = self._make_order(qty=3)
+        self._choose_carrier(order, self.carrier_second)
+        order.order_line.filtered(lambda line: not line.is_delivery).product_uom_qty = 4
+        order.partner_shipping_id = self.partner
+        self.assertEqual(len(self._delivery_line(order)), 1)
+
+    def test_confirmed_order_is_left_alone(self):
+        order = self._make_order(qty=3)
+        order.action_confirm()
+        self.assertEqual(order.state, "sale")
+        # Unrelated to this module: `sale` forbids editing quantities on a
+        # locked order, and this company locks orders on confirmation.
+        order.locked = False
+        price = self._delivery_line(order).price_unit
+        order.order_line.filtered(
+            lambda line: not line.is_delivery
+        ).product_uom_qty = 20
+        self.assertEqual(self._delivery_line(order).price_unit, price)
+
+    def test_lines_written_through_the_order_are_seen(self):
+        # How the form, and most code, saves lines: one2many commands on the
+        # order rather than a write on the line itself.
+        order = self.env["sale.order"].create(
+            {"partner_id": self.partner.id, "pricelist_id": self.pricelist.id}
+        )
+        order.write(
+            {
+                "order_line": [
+                    Command.create(
+                        {"product_id": self.product.id, "product_uom_qty": 3}
+                    )
+                ]
+            }
+        )
+        self.assertEqual(order.carrier_id, self.carrier_first)
+        self.assertFalse(order.delivery_carrier_manual)
+        self.assertEqual(self._delivery_line(order).price_unit, 6.0)
+
+        goods = order.order_line.filtered(lambda line: not line.is_delivery)
+        order.write({"order_line": [Command.update(goods.id, {"product_uom_qty": 10})]})
+        self.assertEqual(self._delivery_line(order).price_unit, 20.0)
+
+        order.write({"order_line": [Command.delete(self._delivery_line(order).id)]})
+        self.assertFalse(order.carrier_id)
+        self.assertTrue(order.delivery_carrier_manual)
+        self.assertFalse(self._delivery_line(order))
+
+    def test_form_save_picks_a_carrier(self):
+        with Form(self.env["sale.order"]) as form:
+            form.partner_id = self.partner
+            with form.order_line.new() as line:
+                line.product_id = self.product
+                line.product_uom_qty = 3
+            # Nothing happens while the form is open: the carrier and its cost
+            # line are decided by the save.
+            self.assertFalse(form.carrier_id)
+        order = form.record
+        self.assertEqual(order.carrier_id, self.carrier_first)
+        self.assertFalse(order.delivery_carrier_manual)
+        self.assertEqual(self._delivery_line(order).price_unit, 6.0)
+        # Which means the order still follows the goods on it.
+        order.order_line.filtered(
+            lambda line: not line.is_delivery
+        ).product_uom_qty = 10
+        self.assertEqual(self._delivery_line(order).price_unit, 20.0)
+
+    def test_form_edit_of_a_saved_order_stays_automatic(self):
+        order = self._make_order(qty=3)
+        with Form(order) as form:
+            with form.order_line.edit(0) as line:
+                line.product_uom_qty = 10
+        self.assertEqual(order.carrier_id, self.carrier_first)
+        self.assertFalse(order.delivery_carrier_manual)
+        self.assertEqual(self._delivery_line(order).price_unit, 20.0)
+
+    def test_deleting_the_delivery_line_is_honoured(self):
+        order = self._make_order(qty=3)
+        self._delivery_line(order).unlink()
+        self.assertFalse(order.carrier_id)
+        self.assertTrue(order.delivery_carrier_manual)
+        order.order_line[0].product_uom_qty = 8
+        self.assertFalse(self._delivery_line(order))

--- a/sale_delivery_auto/views/sale_order.xml
+++ b/sale_delivery_auto/views/sale_order.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <record id="view_order_form" model="ir.ui.view">
+        <field name="name">sale_delivery_auto.sale.order.form</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="delivery.view_order_form_with_carrier" />
+        <field name="arch" type="xml">
+            <xpath
+                expr="//page[@name='other_information']//group[@name='sale_shipping']"
+                position="inside"
+            >
+                <field name="carrier_id" readonly="1" />
+                <field name="delivery_carrier_manual" />
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Fixes T17193

**Dependencies:**
- N/A

**ARL (Associated Risk Level):**
- [ ] Low
- [ ] Medium
- [ ] High

**Type of change:**
- [ ] Forwardport / Backport
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/GlodoUK/codesmith/odoo-addons/pr/319"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790180298&installation_model_id=426334&pr_number=319&repository=GlodoUK%2Fodoo-addons&return_to=https%3A%2F%2Fgithub.com%2FGlodoUK%2Fodoo-addons%2Fpull%2F319&signature=93b2a0d064baf2bb0d8e4646e5d5dcf2363e296cb171440451f2f9ca935a49bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->